### PR TITLE
ISSUE-29: Switch IRQ handler's map from BTreeMap to array

### DIFF
--- a/kernel/interrupt.rs
+++ b/kernel/interrupt.rs
@@ -5,19 +5,33 @@ use crate::{
     net::process_packets,
 };
 use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
 
-// TODO: Use a simple array for faster access.
-static IRQ_HANDLERS: SpinLock<BTreeMap<u8, Box<dyn FnMut() + Send + Sync>>> =
-    SpinLock::new(BTreeMap::new());
+static IRQ_HANDLERS: SpinLock<[Option<Box<dyn FnMut() + Send + Sync>>; 255]> = SpinLock::new([
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+]);
 
 pub fn attach_irq<F: FnMut() + Send + Sync + 'static>(irq: u8, f: F) {
-    IRQ_HANDLERS.lock().insert(irq, Box::new(f));
+    IRQ_HANDLERS.lock()[irq as usize] = Some(Box::new(f));
     enable_irq(irq);
 }
 
 pub fn handle_irq(irq: u8) {
-    if let Some(handler) = IRQ_HANDLERS.lock().get_mut(&irq) {
+    if let Some(handler) = &mut IRQ_HANDLERS.lock()[irq as usize] {
         (*handler)();
         process_packets();
     }

--- a/kernel/interrupt.rs
+++ b/kernel/interrupt.rs
@@ -6,24 +6,9 @@ use crate::{
 };
 use alloc::boxed::Box;
 
-static IRQ_HANDLERS: SpinLock<[Option<Box<dyn FnMut() + Send + Sync>>; 255]> = SpinLock::new([
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-]);
+const DEFAULT_IRQ_HANDLER: Option<Box<dyn FnMut() + Send + Sync>> = None;
+static IRQ_HANDLERS: SpinLock<[Option<Box<dyn FnMut() + Send + Sync>>; 256]> =
+    SpinLock::new([DEFAULT_IRQ_HANDLER; 256]);
 
 pub fn attach_irq<F: FnMut() + Send + Sync + 'static>(irq: u8, f: F) {
     IRQ_HANDLERS.lock()[irq as usize] = Some(Box::new(f));


### PR DESCRIPTION
Fixes #29 

I have very little knowledge of how OS should work, but some parts of IRQ handlers do not feel right.

Here
https://github.com/Lurk/kerla/blob/b213c965d3127a35b429da62fa9d134304107fbf/kernel/interrupt.rs#L28-L31
we do not check if the handler is already assigned. That will definitely lead to strange bugs. 

And here 
https://github.com/Lurk/kerla/blob/b213c965d3127a35b429da62fa9d134304107fbf/kernel/interrupt.rs#L33-L38
The call of net::process_packets feels like it should be done in the handler.

If I am right, should I tackle it in this pull request or create separate issues and pull requests? 