### PR TITLE
[ISSUE-29] IRQ handlers with no conditional branching

### DIFF
--- a/kernel/boot.rs
+++ b/kernel/boot.rs
@@ -10,6 +10,7 @@ use crate::{
         mount::RootFs,
         path::Path,
     },
+    interrupt,
     mm::{global_allocator, page_allocator},
     net, pipe, poll,
     printk::PrintkLogger,
@@ -65,6 +66,7 @@ pub fn boot_kernel(bootinfo: &BootInfo) -> ! {
     // Initialize memory allocators first.
     page_allocator::init(&bootinfo.ram_areas);
     global_allocator::init();
+    interrupt::init();
 
     #[cfg(test)]
     {


### PR DESCRIPTION
I know @Lurk PRed his fix for #29 and it was approved, but this is suggestion how to avoid conditional branching in the interrupt handler. It doesn't panic if the handler is already set yet, but can be added.

You may like it or not, I don't mind if you reject this PR.

Coming from the embedded work first thing that struck me was how to make interrupt handler as efficient as possible; I have even rough idea how to avoid `Box<>` in the array, but that's more work I don't have time for at the moment: we could only keep array of references to trait implementation, and static instances holding particular interrupt handler - if done right it wouldn't even need to panic, assuming IRQ# assignment at compile time is acceptable for all cases.