### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+Kerla's Code of Conduct is based on and almost identical with [Rust's Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct):
+
+## Rules
+- We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristics.
+- Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+- **Please be kind and courteous.** There’s no need to be mean or rude.
+- **Respect that people have differences of opinion** and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+- Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+- We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition in the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md); if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the moderators (see below) immediately. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+## Moderation
+If you feel that a thread in a community space (see below) needs moderation, please contact the moderators list below.
+
+Moderators will check the report and if they consider it inappropriate in respect to the code of conduct, they will:
+
+1. Warn the person in the (public) thread.
+2. If an unacceptable behavior still happens, they will ban temporarily or permanently from the community.
+
+### Moderators
+- Seiya Nuta (nuta@seiya.me)
+
+### Spaces
+Moderators are responsible for managing the following spaces:
+
+- GitHub (https://github.com/nuta/kerla)
+- Discord (https://discord.gg/6Pu4ujpp6h)


### PR DESCRIPTION
This PR adds Code of Conduct to Kerla community to keep welcoming community. It's based on Rust's Code of Conduct (inspired by [Deno](https://github.com/denoland/deno/blob/main/CODE_OF_CONDUCT.md)). Feedbacks are welcome.

closes #20 