### PR TITLE
[#42] process: Reduce indirection of parent field in Process

### DIFF
--- a/kernel/process/fork.rs
+++ b/kernel/process/fork.rs
@@ -28,7 +28,7 @@ pub fn fork(
         process_group: process_group.clone(),
         pid,
         state: ProcessState::Runnable,
-        parent: Some(parent_weak),
+        parent: parent_weak,
         children: Vec::new(),
         vm: Some(Arc::new(SpinLock::new(vm))),
         opened_files: Arc::new(SpinLock::new(opened_files)),


### PR DESCRIPTION
Fixes #42 by removing unnecessary indirection of the `Option<Weak<>>` where `Weak<>` itself is enough as may remain unlinked with `Arc` instance by default (`Weak::new()`) and `.upgrade()` would return `None` in such case.

This will in future reduce unnecessary code to address anything related to `parent` field of the `Process` structure.