### PR TITLE
[#41] process: Implementation of `getppid` syscall

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -130,7 +130,7 @@ Not supported.
 | 107 | geteuid                | Partially             | `v0.0.1` |       |
 | 108 | getegid                | Unimplemented         |          |       |
 | 109 | setpgid                | Partially             | `v0.0.1` |       |
-| 110 | getppid                | Unimplemented         |          |       |
+| 110 | getppid                | Partially             | `v0.0.3` | PR# ? |
 | 111 | getpgrp                | Unimplemented         |          |       |
 | 112 | setsid                 | Unimplemented         |          |       |
 | 113 | setreuid               | Unimplemented         |          |       |

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -235,6 +235,24 @@ impl Process {
         self.pid
     }
 
+    /// The process parent.
+    fn parent(&self) -> Option<Arc<SpinLock<Process>>> {
+        if let Some(parent) = &self.parent.upgrade() {
+            Some(parent.clone())
+        } else {
+            None
+        }
+    }
+
+    /// The ID of process being parent of this process.
+    pub fn ppid(&self) -> PId {
+        if let Some(parent) = self.parent() {
+            parent.lock().pid()
+        } else {
+            PId::new(0)
+        }
+    }
+
     /// The argv. Could be truncated if it's too long.
     pub fn cmdline(&self) -> &str {
         &self.cmdline

--- a/kernel/syscalls/getppid.rs
+++ b/kernel/syscalls/getppid.rs
@@ -1,0 +1,13 @@
+use crate::{
+    prelude::*,
+    process::process_group::PgId,
+    process::{current_process, process_group::ProcessGroup, PId, Process},
+    result::Result,
+    syscalls::SyscallHandler,
+};
+
+impl<'a> SyscallHandler<'a> {
+    pub fn sys_getppid(&mut self) -> Result<isize> {
+        Ok(current_process().ppid().as_i32() as isize)
+    }
+}

--- a/kernel/syscalls/mod.rs
+++ b/kernel/syscalls/mod.rs
@@ -37,6 +37,7 @@ pub(self) mod getdents64;
 pub(self) mod getpeername;
 pub(self) mod getpgid;
 pub(self) mod getpid;
+pub(self) mod getppid;
 pub(self) mod getrandom;
 pub(self) mod getsockname;
 pub(self) mod getsockopt;
@@ -146,6 +147,7 @@ const SYS_SETUID: usize = 105;
 const SYS_SETGID: usize = 106;
 const SYS_GETEUID: usize = 107;
 const SYS_SETPGID: usize = 109;
+const SYS_GETPPID: usize = 110;
 const SYS_GETPGID: usize = 121;
 const SYS_SETGROUPS: usize = 116;
 const SYS_ARCH_PRCTL: usize = 158;
@@ -289,6 +291,7 @@ impl<'a> SyscallHandler<'a> {
             SYS_SETGID => Ok(0),    // TODO:
             SYS_SETGROUPS => Ok(0), // TODO:
             SYS_SETPGID => self.sys_setpgid(PId::new(a1 as i32), PgId::new(a2 as i32)),
+            SYS_GETPPID => self.sys_getppid(),
             SYS_SET_TID_ADDRESS => self.sys_set_tid_address(UserVAddr::new_nonnull(a1)?),
             SYS_PIPE => self.sys_pipe(UserVAddr::new_nonnull(a1)?),
             SYS_RT_SIGACTION => self.sys_rt_sigaction(a1 as c_int, a2, UserVAddr::new(a3)?),


### PR DESCRIPTION
Fixes #41 by adding the implementation of the `getppid` system call.