### PR TITLE
move net::process_packets() call from interrupt::handle_irq to handler

### DIFF
--- a/kernel/drivers/virtio/virtio_net.rs
+++ b/kernel/drivers/virtio/virtio_net.rs
@@ -1,6 +1,6 @@
 //! A virtio-net device driver.
 use super::virtio::{IsrStatus, Virtio};
-use crate::net::receive_ethernet_frame;
+use crate::net::{process_packets, receive_ethernet_frame};
 use crate::{
     arch::{SpinLock, VAddr, PAGE_SIZE},
     boot::VirtioMmioDevice,
@@ -237,6 +237,7 @@ impl DriverBuilder for VirtioNetBuilder {
         register_ethernet_driver(driver.clone());
         attach_irq(pci_device.config().interrupt_line(), move || {
             driver.lock().handle_irq();
+            process_packets();
         });
 
         Ok(())
@@ -270,6 +271,7 @@ impl DriverBuilder for VirtioNetBuilder {
 
         attach_irq(mmio_device.irq, move || {
             driver.lock().handle_irq();
+            process_packets();
         });
 
         Ok(())

--- a/kernel/interrupt.rs
+++ b/kernel/interrupt.rs
@@ -1,16 +1,15 @@
 //! Interrupt handling.
 
-use crate::{
-    arch::{enable_irq, SpinLock},
-    net::process_packets,
-};
+use crate::arch::{enable_irq, SpinLock};
 use alloc::boxed::Box;
 use core::mem::MaybeUninit;
 
 fn empty_irq_handler() {}
 
-const UNINITIALIZED_IRQ_HANDLER: MaybeUninit<Box<dyn FnMut() + Send + Sync>> = MaybeUninit::uninit();
-static IRQ_HANDLERS: SpinLock<[MaybeUninit<Box<dyn FnMut() + Send + Sync>>; 256]> = SpinLock::new([UNINITIALIZED_IRQ_HANDLER; 256]);
+const UNINITIALIZED_IRQ_HANDLER: MaybeUninit<Box<dyn FnMut() + Send + Sync>> =
+    MaybeUninit::uninit();
+static IRQ_HANDLERS: SpinLock<[MaybeUninit<Box<dyn FnMut() + Send + Sync>>; 256]> =
+    SpinLock::new([UNINITIALIZED_IRQ_HANDLER; 256]);
 
 pub fn init() {
     let mut handlers = IRQ_HANDLERS.lock();
@@ -26,6 +25,7 @@ pub fn attach_irq<F: FnMut() + Send + Sync + 'static>(irq: u8, f: F) {
 
 pub fn handle_irq(irq: u8) {
     let handler = &mut IRQ_HANDLERS.lock()[irq as usize];
-    unsafe { (*handler.assume_init_mut())(); }
-    process_packets();
+    unsafe {
+        (*handler.assume_init_mut())();
+    }
 }


### PR DESCRIPTION
As discussed in #35 - net::process_packets() must be called in handler.
