### PR TITLE
Panic on irq_handler overwrite

### DIFF
--- a/kernel/interrupt.rs
+++ b/kernel/interrupt.rs
@@ -3,43 +3,39 @@
 use crate::arch::{enable_irq, SpinLock};
 use alloc::boxed::Box;
 use core::mem::MaybeUninit;
+use kerla_utils::bitmap::BitMap;
 
-fn empty_irq_callback() {}
+fn empty_irq_handler() {}
 
-struct IrqHandler {
-    callback: Box<dyn FnMut() + Send + Sync>,
-    attached: bool,
-}
-
-const UNINITIALIZED_IRQ_HANDLER: MaybeUninit<IrqHandler> = MaybeUninit::uninit();
-static IRQ_HANDLERS: SpinLock<[MaybeUninit<IrqHandler>; 256]> =
+type IrqHandler = dyn FnMut() + Send + Sync;
+const UNINITIALIZED_IRQ_HANDLER: MaybeUninit<Box<IrqHandler>> = MaybeUninit::uninit();
+static IRQ_HANDLERS: SpinLock<[MaybeUninit<Box<IrqHandler>>; 256]> =
     SpinLock::new([UNINITIALIZED_IRQ_HANDLER; 256]);
+static ATTACHED_IRQS: SpinLock<BitMap<32 /* = 256 / 8 */>> = SpinLock::new(BitMap::zeroed());
 
 pub fn init() {
     let mut handlers = IRQ_HANDLERS.lock();
     for handler in handlers.iter_mut() {
-        handler.write(IrqHandler {
-            callback: Box::new(empty_irq_callback),
-            attached: false,
-        });
+        handler.write(Box::new(empty_irq_handler));
     }
 }
 
-pub fn attach_irq<F: FnMut() + Send + Sync + 'static>(irq: u8, callback: F) {
-    let h = &mut IRQ_HANDLERS.lock()[irq as usize];
-    let irq_handler = unsafe { h.assume_init_mut() };
-    if irq_handler.attached {
-        panic!("handler for IRQ #{} is already attached", irq);
-    } else {
-        irq_handler.attached = true;
-        irq_handler.callback = Box::new(callback);
-        enable_irq(irq);
+pub fn attach_irq<F: FnMut() + Send + Sync + 'static>(irq: u8, f: F) {
+    let mut attached_irq_map = ATTACHED_IRQS.lock();
+    match attached_irq_map.get(irq as usize) {
+        Some(true) => panic!("handler for IRQ #{} is already attached", irq),
+        Some(false) => {
+            attached_irq_map.set(irq as usize);
+            IRQ_HANDLERS.lock()[irq as usize].write(Box::new(f));
+            enable_irq(irq);
+        }
+        None => panic!("IRQ #{} is out of bound", irq),
     }
 }
 
 pub fn handle_irq(irq: u8) {
     let handler = &mut IRQ_HANDLERS.lock()[irq as usize];
     unsafe {
-        (*handler.assume_init_mut().callback)();
+        (*handler.assume_init_mut())();
     }
 }

--- a/kernel/interrupt.rs
+++ b/kernel/interrupt.rs
@@ -4,28 +4,42 @@ use crate::arch::{enable_irq, SpinLock};
 use alloc::boxed::Box;
 use core::mem::MaybeUninit;
 
-fn empty_irq_handler() {}
+fn empty_irq_callback() {}
 
-type IrqHandler = dyn FnMut() + Send + Sync;
-const UNINITIALIZED_IRQ_HANDLER: MaybeUninit<Box<IrqHandler>> = MaybeUninit::uninit();
-static IRQ_HANDLERS: SpinLock<[MaybeUninit<Box<IrqHandler>>; 256]> =
+struct IrqHandler {
+    callback: Box<dyn FnMut() + Send + Sync>,
+    attached: bool,
+}
+
+const UNINITIALIZED_IRQ_HANDLER: MaybeUninit<IrqHandler> = MaybeUninit::uninit();
+static IRQ_HANDLERS: SpinLock<[MaybeUninit<IrqHandler>; 256]> =
     SpinLock::new([UNINITIALIZED_IRQ_HANDLER; 256]);
 
 pub fn init() {
     let mut handlers = IRQ_HANDLERS.lock();
     for handler in handlers.iter_mut() {
-        handler.write(Box::new(empty_irq_handler));
+        handler.write(IrqHandler {
+            callback: Box::new(empty_irq_callback),
+            attached: false,
+        });
     }
 }
 
-pub fn attach_irq<F: FnMut() + Send + Sync + 'static>(irq: u8, f: F) {
-    IRQ_HANDLERS.lock()[irq as usize].write(Box::new(f));
-    enable_irq(irq);
+pub fn attach_irq<F: FnMut() + Send + Sync + 'static>(irq: u8, callback: F) {
+    let h = &mut IRQ_HANDLERS.lock()[irq as usize];
+    let irq_handler = unsafe { h.assume_init_mut() };
+    if irq_handler.attached {
+        panic!("handler for IRQ #{} is already attached", irq);
+    } else {
+        irq_handler.attached = true;
+        irq_handler.callback = Box::new(callback);
+        enable_irq(irq);
+    }
 }
 
 pub fn handle_irq(irq: u8) {
     let handler = &mut IRQ_HANDLERS.lock()[irq as usize];
     unsafe {
-        (*handler.assume_init_mut())();
+        (*handler.assume_init_mut().callback)();
     }
 }


### PR DESCRIPTION
Fixes #50 

In this PR we introduce struct IrqHandler. 

```rust
struct IrqHandler {
    callback: Box<dyn FnMut() + Send + Sync>,
    attached: bool,
}
```

Right now there is only one ancillary field - attached, which allows an "overwrite" check. But potentially opens the way to build something like  /proc/interrupts.