### PR TITLE
Fix opened file locking

### DIFF
--- a/kernel/fs/inode.rs
+++ b/kernel/fs/inode.rs
@@ -274,7 +274,8 @@ impl INode {
 
     /// `chmod(2)`
     pub fn chmod(&self, _mode: FileMode) -> Result<()> {
-        Err(Error::new(Errno::ENOSYS))
+        // FIXME: Ignore all chmod requests for now.
+        Ok(())
     }
 }
 

--- a/kernel/fs/mount.rs
+++ b/kernel/fs/mount.rs
@@ -161,7 +161,7 @@ impl RootFs {
                 CwdOrFd::AtCwd => Ok(self.cwd_path.clone()),
                 CwdOrFd::Fd(fd) => {
                     let opened_file = opened_files.get(*fd)?;
-                    Ok(opened_file.lock().path().clone())
+                    Ok(opened_file.path().clone())
                 }
             }
         }

--- a/kernel/fs/opened_file.rs
+++ b/kernel/fs/opened_file.rs
@@ -373,7 +373,7 @@ impl OpenedFileTable {
             }
             Some(entry @ None) => {
                 *entry = Some(LocalOpenedFile {
-                    opened_file: opened_file.clone(),
+                    opened_file,
                     close_on_exec: options.close_on_exec,
                 });
             }
@@ -383,7 +383,7 @@ impl OpenedFileTable {
             None => {
                 self.files.resize(fd.as_usize() + 1, None);
                 self.files[fd.as_usize()] = Some(LocalOpenedFile {
-                    opened_file: opened_file.clone(),
+                    opened_file,
                     close_on_exec: options.close_on_exec,
                 });
             }

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -145,31 +145,27 @@ impl Process {
         // Open stdin.
         opened_files.open_with_fixed_fd(
             Fd::new(0),
-            Arc::new(SpinLock::new(OpenedFile::new(
+            Arc::new(OpenedFile::new(
                 console.clone(),
                 OpenFlags::O_RDONLY.into(),
                 0,
-            ))),
+            )),
             OpenOptions::empty(),
         )?;
         // Open stdout.
         opened_files.open_with_fixed_fd(
             Fd::new(1),
-            Arc::new(SpinLock::new(OpenedFile::new(
+            Arc::new(OpenedFile::new(
                 console.clone(),
                 OpenFlags::O_WRONLY.into(),
                 0,
-            ))),
+            )),
             OpenOptions::empty(),
         )?;
         // Open stderr.
         opened_files.open_with_fixed_fd(
             Fd::new(2),
-            Arc::new(SpinLock::new(OpenedFile::new(
-                console,
-                OpenFlags::O_WRONLY.into(),
-                0,
-            ))),
+            Arc::new(OpenedFile::new(console, OpenFlags::O_WRONLY.into(), 0)),
             OpenOptions::empty(),
         )?;
 
@@ -305,7 +301,7 @@ impl Process {
     }
 
     /// Searches the opned file table by the file descriptor.
-    pub fn get_opened_file_by_fd(&self, fd: Fd) -> Result<Arc<SpinLock<OpenedFile>>> {
+    pub fn get_opened_file_by_fd(&self, fd: Fd) -> Result<Arc<OpenedFile>> {
         Ok(self.opened_files.lock().get(fd)?.clone())
     }
 

--- a/kernel/syscalls/accept.rs
+++ b/kernel/syscalls/accept.rs
@@ -15,7 +15,7 @@ impl<'a> SyscallHandler<'a> {
         socklen: Option<UserVAddr>,
     ) -> Result<isize> {
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        let (sock, accepted_sockaddr) = opened_file.lock().accept()?;
+        let (sock, accepted_sockaddr) = opened_file.accept()?;
 
         let options = OpenOptions {
             nonblock: false,

--- a/kernel/syscalls/bind.rs
+++ b/kernel/syscalls/bind.rs
@@ -6,7 +6,7 @@ impl<'a> SyscallHandler<'a> {
     pub fn sys_bind(&mut self, fd: Fd, addr: UserVAddr, addr_len: usize) -> Result<isize> {
         let sockaddr = read_sockaddr(addr, addr_len)?;
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        opened_file.lock().bind(sockaddr)?;
+        opened_file.bind(sockaddr)?;
         Ok(0)
     }
 }

--- a/kernel/syscalls/connect.rs
+++ b/kernel/syscalls/connect.rs
@@ -6,7 +6,7 @@ impl<'a> SyscallHandler<'a> {
     pub fn sys_connect(&mut self, fd: Fd, addr: UserVAddr, addr_len: usize) -> Result<isize> {
         let sockaddr = read_sockaddr(addr, addr_len)?;
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        opened_file.lock().connect(sockaddr)?;
+        opened_file.connect(sockaddr)?;
         Ok(0)
     }
 }

--- a/kernel/syscalls/fcntl.rs
+++ b/kernel/syscalls/fcntl.rs
@@ -19,13 +19,12 @@ impl<'a> SyscallHandler<'a> {
         let mut opened_files = current.opened_files().lock();
         match cmd {
             F_SETFD => {
-                opened_files.get(fd)?.lock().set_cloexec(arg == 1);
+                opened_files.get(fd)?.set_cloexec(arg == 1);
                 Ok(0)
             }
             F_SETFL => {
                 opened_files
                     .get(fd)?
-                    .lock()
                     .set_flags(OpenFlags::from_bits_truncate(arg as i32))?;
                 Ok(0)
             }

--- a/kernel/syscalls/fstat.rs
+++ b/kernel/syscalls/fstat.rs
@@ -5,7 +5,7 @@ use crate::{process::current_process, syscalls::SyscallHandler};
 impl<'a> SyscallHandler<'a> {
     pub fn sys_fstat(&mut self, fd: Fd, buf: UserVAddr) -> Result<isize> {
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        let stat = opened_file.lock().path().inode.stat()?;
+        let stat = opened_file.path().inode.stat()?;
         buf.write(&stat)?;
         Ok(0)
     }

--- a/kernel/syscalls/fsync.rs
+++ b/kernel/syscalls/fsync.rs
@@ -6,7 +6,7 @@ use crate::syscalls::SyscallHandler;
 impl<'a> SyscallHandler<'a> {
     pub fn sys_fsync(&mut self, fd: Fd) -> Result<isize> {
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        opened_file.lock().fsync()?;
+        opened_file.fsync()?;
         Ok(0)
     }
 }

--- a/kernel/syscalls/getdents64.rs
+++ b/kernel/syscalls/getdents64.rs
@@ -10,7 +10,7 @@ impl<'a> SyscallHandler<'a> {
     pub fn sys_getdents64(&mut self, fd: Fd, dirp: UserVAddr, len: usize) -> Result<isize> {
         let current = current_process();
         let opened_files = current.opened_files().lock();
-        let mut dir = opened_files.get(fd)?.lock();
+        let dir = opened_files.get(fd)?;
         let mut writer = UserBufWriter::from_uaddr(dirp, len);
         while let Some(entry) = dir.readdir()? {
             let alignment = size_of::<u64>();

--- a/kernel/syscalls/getpeername.rs
+++ b/kernel/syscalls/getpeername.rs
@@ -12,7 +12,6 @@ impl<'a> SyscallHandler<'a> {
             .opened_files()
             .lock()
             .get(fd)?
-            .lock()
             .getpeername()?;
 
         write_sockaddr(&endpoint, Some(sockaddr), Some(socklen))?;

--- a/kernel/syscalls/getsockname.rs
+++ b/kernel/syscalls/getsockname.rs
@@ -12,7 +12,6 @@ impl<'a> SyscallHandler<'a> {
             .opened_files()
             .lock()
             .get(fd)?
-            .lock()
             .getsockname()?;
 
         write_sockaddr(&endpoint, Some(sockaddr), Some(socklen))?;

--- a/kernel/syscalls/ioctl.rs
+++ b/kernel/syscalls/ioctl.rs
@@ -5,7 +5,7 @@ use crate::{fs::opened_file::Fd, process::current_process};
 impl<'a> SyscallHandler<'a> {
     pub fn sys_ioctl(&mut self, fd: Fd, cmd: usize, arg: usize) -> Result<isize> {
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        let ret = opened_file.lock().ioctl(cmd, arg);
+        let ret = opened_file.ioctl(cmd, arg);
         ret
     }
 }

--- a/kernel/syscalls/ioctl.rs
+++ b/kernel/syscalls/ioctl.rs
@@ -5,7 +5,6 @@ use crate::{fs::opened_file::Fd, process::current_process};
 impl<'a> SyscallHandler<'a> {
     pub fn sys_ioctl(&mut self, fd: Fd, cmd: usize, arg: usize) -> Result<isize> {
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        let ret = opened_file.ioctl(cmd, arg);
-        ret
+        opened_file.ioctl(cmd, arg)
     }
 }

--- a/kernel/syscalls/listen.rs
+++ b/kernel/syscalls/listen.rs
@@ -5,7 +5,7 @@ use crate::{process::current_process, syscalls::SyscallHandler};
 impl<'a> SyscallHandler<'a> {
     pub fn sys_listen(&mut self, fd: Fd, backlog: c_int) -> Result<isize> {
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        opened_file.lock().listen(backlog)?;
+        opened_file.listen(backlog)?;
         Ok(0)
     }
 }

--- a/kernel/syscalls/mmap.rs
+++ b/kernel/syscalls/mmap.rs
@@ -32,7 +32,6 @@ impl<'a> SyscallHandler<'a> {
                 .opened_files()
                 .lock()
                 .get(fd)?
-                .lock()
                 .as_file()?
                 .clone();
 

--- a/kernel/syscalls/poll.rs
+++ b/kernel/syscalls/poll.rs
@@ -33,12 +33,7 @@ impl<'a> SyscallHandler<'a> {
                 let revents = if fd.as_int() < 0 || events.is_empty() {
                     0
                 } else {
-                    let status = current_process()
-                        .opened_files()
-                        .lock()
-                        .get(fd)?
-                        .lock()
-                        .poll()?;
+                    let status = current_process().opened_files().lock().get(fd)?.poll()?;
 
                     let revents = events & status;
                     if !revents.is_empty() {

--- a/kernel/syscalls/read.rs
+++ b/kernel/syscalls/read.rs
@@ -12,13 +12,11 @@ impl<'a> SyscallHandler<'a> {
             "[{}:{}] read(file={:?}, len={})",
             current_process().pid().as_i32(),
             current_process().cmdline().argv0(),
-            opened_file.lock().inode(),
+            opened_file.inode(),
             len
         );
 
-        let read_len = opened_file
-            .lock()
-            .read(UserBufferMut::from_uaddr(uaddr, len))?;
+        let read_len = opened_file.read(UserBufferMut::from_uaddr(uaddr, len))?;
 
         // MAX_READ_WRITE_LEN limit guarantees total_len is in the range of isize.
         Ok(read_len as isize)

--- a/kernel/syscalls/readlink.rs
+++ b/kernel/syscalls/readlink.rs
@@ -18,7 +18,6 @@ impl<'a> SyscallHandler<'a> {
                 .opened_files()
                 .lock()
                 .get(Fd::new(fd))?
-                .lock()
                 .path()
                 .resolve_absolute_path()
         } else {

--- a/kernel/syscalls/recvfrom.rs
+++ b/kernel/syscalls/recvfrom.rs
@@ -17,9 +17,8 @@ impl<'a> SyscallHandler<'a> {
         let len = min(len, MAX_READ_WRITE_LEN);
 
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        let (read_len, sockaddr) = opened_file
-            .lock()
-            .recvfrom(UserBufferMut::from_uaddr(uaddr, len), flags)?;
+        let (read_len, sockaddr) =
+            opened_file.recvfrom(UserBufferMut::from_uaddr(uaddr, len), flags)?;
 
         write_sockaddr(&sockaddr, src_addr, addr_len)?;
 

--- a/kernel/syscalls/select.rs
+++ b/kernel/syscalls/select.rs
@@ -28,12 +28,7 @@ where
         for bit_i in 0..8 {
             let fd = Fd::new((byte_i * 8 + bit_i) as c_int);
             if *byte & (1 << bit_i) != 0 && fd.as_int() <= max_fd {
-                let status = current_process()
-                    .opened_files()
-                    .lock()
-                    .get(fd)?
-                    .lock()
-                    .poll()?;
+                let status = current_process().opened_files().lock().get(fd)?.poll()?;
 
                 if is_ready(status) {
                     ready_fds += 1;

--- a/kernel/syscalls/sendto.rs
+++ b/kernel/syscalls/sendto.rs
@@ -24,9 +24,7 @@ impl<'a> SyscallHandler<'a> {
         };
 
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
-        let sent_len = opened_file
-            .lock()
-            .sendto(UserBuffer::from_uaddr(uaddr, len), sockaddr)?;
+        let sent_len = opened_file.sendto(UserBuffer::from_uaddr(uaddr, len), sockaddr)?;
 
         // MAX_READ_WRITE_LEN limit guarantees total_len is in the range of isize.
         Ok(sent_len as isize)

--- a/kernel/syscalls/write.rs
+++ b/kernel/syscalls/write.rs
@@ -13,13 +13,11 @@ impl<'a> SyscallHandler<'a> {
             "[{}:{}] write(file={:?}, len={})",
             current_process().pid().as_i32(),
             current_process().cmdline().argv0(),
-            opened_file.lock().inode(),
+            opened_file.inode(),
             len
         );
 
-        let written_len = opened_file
-            .lock()
-            .write(UserBuffer::from_uaddr(uaddr, len))?;
+        let written_len = opened_file.write(UserBuffer::from_uaddr(uaddr, len))?;
 
         // MAX_READ_WRITE_LEN limit guarantees total_len is in the range of isize.
         Ok(written_len as isize)

--- a/kernel/syscalls/writev.rs
+++ b/kernel/syscalls/writev.rs
@@ -31,9 +31,7 @@ impl<'a> SyscallHandler<'a> {
                 continue;
             }
 
-            total_len += opened_file
-                .lock()
-                .write(UserBuffer::from_uaddr(iov.base, iov.len))?;
+            total_len += opened_file.write(UserBuffer::from_uaddr(iov.base, iov.len))?;
         }
 
         // MAX_READ_WRITE_LEN limit guarantees total_len is in the range of isize.


### PR DESCRIPTION
The same OpenedFile can be accessed from multiple processes (from a forked processes) and
`Arc<SpinLock<OpenedFile>>` leads to a busy spin lock if, for example, read blocks.

Make its locking more fine-grained to prenvet the busy loop.

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
