### PR TITLE
spinlock: Improve the debug message on a dead lock

### DIFF
--- a/kernel/arch/x64/lock.rs
+++ b/kernel/arch/x64/lock.rs
@@ -1,17 +1,24 @@
+use atomic_refcell::AtomicRefCell;
+use cfg_if::cfg_if;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
 use x86::current::rflags::{self, RFlags};
 
-use crate::printk::backtrace;
+use crate::mm::global_allocator::is_kernel_heap_enabled;
+use crate::printk::{backtrace, capture_backtrace, CapturedBacktrace};
 
 pub struct SpinLock<T: ?Sized> {
-    pub inner: spin::mutex::SpinMutex<T>,
+    #[cfg(debug_assertions)]
+    locked_by: AtomicRefCell<Option<CapturedBacktrace>>,
+    inner: spin::mutex::SpinMutex<T>,
 }
 
 impl<T> SpinLock<T> {
     pub const fn new(value: T) -> SpinLock<T> {
         SpinLock {
             inner: spin::mutex::SpinMutex::new(value),
+            #[cfg(debug_assertions)]
+            locked_by: AtomicRefCell::new(None),
         }
     }
 }
@@ -24,7 +31,23 @@ impl<T: ?Sized> SpinLock<T> {
             // unless a dead lock has occurred.
             //
             // TODO: Remove when we got SMP support.
-            debug_warn!("already locked");
+            cfg_if! {
+                if #[cfg(debug_assertions)] {
+                    let trace = self.locked_by.borrow();
+                    if let Some(trace) = trace.as_ref() {
+                        debug_warn!(
+                            "DEAD LOCK: already locked from the following context\n{:?}",
+                            trace
+                        );
+                    } else {
+                        debug_warn!("DEAD LOCK: already locked");
+                    }
+                } else {
+                    debug_warn!("DEAD LOCK: already locked");
+                }
+            }
+
+            debug_warn!("Tried to lock from:");
             backtrace();
         }
 
@@ -33,9 +56,18 @@ impl<T: ?Sized> SpinLock<T> {
             asm!("cli");
         }
 
+        let guard = self.inner.lock();
+
+        #[cfg(debug_assertions)]
+        if is_kernel_heap_enabled() {
+            *self.locked_by.borrow_mut() = Some(capture_backtrace());
+        }
+
         SpinLockGuard {
-            inner: ManuallyDrop::new(self.inner.lock()),
+            inner: ManuallyDrop::new(guard),
             rflags,
+            #[cfg(debug_assertions)]
+            locked_by: &self.locked_by,
         }
     }
 
@@ -49,6 +81,8 @@ unsafe impl<T: ?Sized + Send> Send for SpinLock<T> {}
 
 pub struct SpinLockGuard<'a, T: ?Sized> {
     inner: ManuallyDrop<spin::mutex::SpinMutexGuard<'a, T>>,
+    #[cfg(debug_assertions)]
+    locked_by: &'a AtomicRefCell<Option<CapturedBacktrace>>,
     rflags: RFlags,
 }
 
@@ -57,6 +91,12 @@ impl<'a, T: ?Sized> Drop for SpinLockGuard<'a, T> {
         unsafe {
             ManuallyDrop::drop(&mut self.inner);
             rflags::set(rflags::read() | (self.rflags & rflags::RFlags::FLAGS_IF));
+        }
+
+        cfg_if! {
+            if #[cfg(debug_assertions)] {
+                *self.locked_by.borrow_mut() = None;
+            }
         }
     }
 }


### PR DESCRIPTION
Print where the lock is being held on a dead lock:

```
[   0.327] WARN: DEAD LOCK: already locked from the following context
    #1: ffff800000222c89  kerla::printk::capture_backtrace()+0x79
    #2: ffff8000001ed69b  kerla::arch::x64::lock::SpinLock<T>::lock()+0x81b
    #3: ffff80000014220b  kerla::syscalls::ioctl::<i...yscallHandler>::sys_ioctl()+0x16b
    #4: ffff80000014cf08  kerla::syscalls::SyscallHandler::do_dispatch()+0x2928
    #5: ffff800000149dbc  kerla::syscalls::SyscallHandler::dispatch()+0x1ac
    #6: ffff8000001b7fdc  x64_handle_syscall()+0x9c
    #7: ffff800000100235  syscall_entry()+0x3d

[   0.327] WARN: Tried to lock from:
[   0.327]     0: ffff800000222c0a  kerla::printk::backtrace()+0x1a
[   0.327]     1: ffff8000001ed589  kerla::arch::x64::lock::SpinLock<T>::lock()+0x709
[   0.327]     2: ffff80000014222e  kerla::syscalls::ioctl::<i...yscallHandler>::sys_ioctl()+0x18e
[   0.327]     3: ffff80000014cf08  kerla::syscalls::SyscallHandler::do_dispatch()+0x2928
[   0.327]     4: ffff800000149dbc  kerla::syscalls::SyscallHandler::dispatch()+0x1ac
[   0.327]     5: ffff8000001b7fdc  x64_handle_syscall()+0x9c
[   0.327]     6: ffff800000100235  syscall_entry()+0x3d
```

This example output is generated by:

```rust
    pub fn sys_ioctl(&mut self, fd: Fd, cmd: usize, arg: usize) -> Result<isize> {
        let opened_file = current_process().get_opened_file_by_fd(fd)?;
        let foo = opened_file.lock(); // 1st lock here
        let ret = opened_file.lock().ioctl(cmd, arg); // 2nd lock here (causes a dead lock!)
        ret
    }
```