### PR TITLE
Call `arch::print_str()` directly on double panic

### DIFF
--- a/kernel/lang_items.rs
+++ b/kernel/lang_items.rs
@@ -8,6 +8,11 @@ pub static PANICKED: AtomicBool = AtomicBool::new(false);
 fn panic(info: &core::panic::PanicInfo) -> ! {
     use core::sync::atomic::Ordering;
 
+    if PANICKED.load(Ordering::SeqCst) {
+        crate::arch::print_str(b"double panic!\n");
+        crate::arch::halt();
+    }
+
     PANICKED.store(true, Ordering::SeqCst);
     error!("{}", info);
     crate::printk::backtrace();


### PR DESCRIPTION
To prevent recursive panicking.

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
