### PR TITLE
Single thread gettid syscall implementation

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -206,7 +206,7 @@ Not supported.
 | 183 | afs_syscall            | Unimplemented         |          |                                            |
 | 184 | tuxcall                | Unimplemented         |          |                                            |
 | 185 | security               | Unimplemented         |          |                                            |
-| 186 | gettid                 | Unimplemented         |          |                                            |
+| 186 | gettid                 | Partialy              |          | Single thread implementation               |
 | 187 | readahead              | Unimplemented         |          |                                            |
 | 188 | setxattr               | Unimplemented         |          |                                            |
 | 189 | lsetxattr              | Unimplemented         |          |                                            |

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -209,6 +209,8 @@ impl Process {
 
     /// The thread ID.
     pub fn tid(&self) -> PId {
+        // In a single-threaded process, the thread ID is equal to the process ID (PID).
+        // https://man7.org/linux/man-pages/man2/gettid.2.html
         self.pid
     }
 

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -207,6 +207,11 @@ impl Process {
         self.pid
     }
 
+    /// The thread ID
+    pub fn tid(&self) -> PId {
+        self.pid
+    }
+
     /// The arch-specific information.
     pub fn arch(&self) -> &arch::Process {
         &self.arch

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -207,7 +207,7 @@ impl Process {
         self.pid
     }
 
-    /// The thread ID
+    /// The thread ID.
     pub fn tid(&self) -> PId {
         self.pid
     }

--- a/kernel/syscalls/gettid.rs
+++ b/kernel/syscalls/gettid.rs
@@ -1,0 +1,9 @@
+use crate::{process::current_process, result::Result, syscalls::SyscallHandler};
+
+impl<'a> SyscallHandler<'a> {
+    /// returns the caller's thread ID (TID).  
+    /// In a single-threaded process, the thread ID is equal to the process ID (PID)
+    pub fn sys_gettid(&mut self) -> Result<isize> {
+        Ok(current_process().pid().as_i32() as isize)
+    }
+}

--- a/kernel/syscalls/gettid.rs
+++ b/kernel/syscalls/gettid.rs
@@ -1,9 +1,7 @@
 use crate::{process::current_process, result::Result, syscalls::SyscallHandler};
 
 impl<'a> SyscallHandler<'a> {
-    /// returns the caller's thread ID (TID).  
-    /// In a single-threaded process, the thread ID is equal to the process ID (PID)
     pub fn sys_gettid(&mut self) -> Result<isize> {
-        Ok(current_process().pid().as_i32() as isize)
+        Ok(current_process().tid().as_i32() as isize)
     }
 }

--- a/kernel/syscalls/mod.rs
+++ b/kernel/syscalls/mod.rs
@@ -41,6 +41,7 @@ pub(self) mod getppid;
 pub(self) mod getrandom;
 pub(self) mod getsockname;
 pub(self) mod getsockopt;
+pub(self) mod gettid;
 pub(self) mod ioctl;
 pub(self) mod link;
 pub(self) mod linkat;
@@ -153,6 +154,7 @@ const SYS_GETPGID: usize = 121;
 const SYS_SETGROUPS: usize = 116;
 const SYS_ARCH_PRCTL: usize = 158;
 const SYS_REBOOT: usize = 169;
+const SYS_GETTID: usize = 186;
 const SYS_GETDENTS64: usize = 217;
 const SYS_SET_TID_ADDRESS: usize = 218;
 const SYS_CLOCK_GETTIME: usize = 228;
@@ -364,6 +366,7 @@ impl<'a> SyscallHandler<'a> {
             ),
             SYS_SYSLOG => self.sys_syslog(a1 as c_int, UserVAddr::new(a2)?, a3 as c_int),
             SYS_REBOOT => self.sys_reboot(a1 as c_int, a2 as c_int, a3),
+            SYS_GETTID => self.sys_gettid(),
             _ => {
                 debug_warn!(
                     "unimplemented system call: {} (n={})",


### PR DESCRIPTION
This PR is about adding gettid syscall implementation.

Motivation: reduce noise (count of unimplemented system call warnings) in integration tests.

Since we do not have multiple threads per process we always return process ID (PID).

I am not sure if `Process.tid` and all machinery around it should be added in this PR, or in separate.

