### PR TITLE
Release IRQ_HANDLERS' lock before running deferred jobs

### DIFF
--- a/kernel/interrupt.rs
+++ b/kernel/interrupt.rs
@@ -36,10 +36,17 @@ pub fn attach_irq(irq: u8, f: Box<dyn FnMut() + Send + Sync + 'static>) {
 }
 
 pub fn handle_irq(irq: u8) {
-    let handler = &mut IRQ_HANDLERS.lock()[irq as usize];
-    unsafe {
-        (*handler.assume_init_mut())();
+    {
+        let handler = &mut IRQ_HANDLERS.lock()[irq as usize];
+        unsafe {
+            (*handler.assume_init_mut())();
+        }
+
+        // `handler` is dropped here to release IRQ_HANDLERS's lock here since
+        // we re-enable interrupts just before running deferred jobs.
     }
+
+    // TODO: Re-enable interrupts to make deferred jobs preemptive.
 
     // So-called "bottom half" in Linux kernel. Execute time-consuming but
     // non-critical work like processing packets.

--- a/kernel/interrupt.rs
+++ b/kernel/interrupt.rs
@@ -42,7 +42,7 @@ pub fn handle_irq(irq: u8) {
             (*handler.assume_init_mut())();
         }
 
-        // `handler` is dropped here to release IRQ_HANDLERS's lock here since
+        // `handler` is dropped here to release IRQ_HANDLERS's lock since
         // we re-enable interrupts just before running deferred jobs.
     }
 


### PR DESCRIPTION
Reported-By: @Lurk

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
