### PR TITLE
Generate the kernel extensions loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,13 +166,21 @@ dependencies = [
  "goblin",
  "hashbrown",
  "kerla_api",
+ "kerla_kexts_loader",
  "kerla_runtime",
  "kerla_utils",
  "log",
  "smoltcp",
  "spin 0.9.2",
- "virtio_net",
  "x86",
+]
+
+[[package]]
+name = "kerla_kexts_loader"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "virtio_net",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "kernel",
     "libs/*",
     "exts/*",
+    "build/kexts_loader",
 ]
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ export V         ?=
 export GUI       ?=
 export RELEASE   ?=
 export ARCH      ?= x64
+export KEXTS     ?= $(patsubst exts/%/Cargo.toml,%,$(wildcard exts/*/Cargo.toml))
 
 # The default build target.
 .PHONY: default
@@ -86,6 +87,10 @@ build:
 .PHONY: build-crate
 build-crate:
 	$(MAKE) initramfs
+
+	$(PROGRESS) "GEN" "kexts-loader ($(KEXTS))"
+	$(PYTHON3) tools/generate-kexts-loader.py --out-dir build/kexts_loader $(KEXTS)
+
 	$(PROGRESS) "CARGO" "kernel"
 	$(CARGO) build $(CARGOFLAGS) --manifest-path kernel/Cargo.toml
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -29,5 +29,5 @@ kerla_runtime = { path = "../runtime" }
 kerla_api = { path = "../libs/kerla_api" }
 kerla_utils = { path = "../libs/kerla_utils", features = ["no_std"] }
 
-# Kernel extensions.
-virtio_net = { path = "../exts/virtio_net" }
+# Automatically generated dependencies.
+kerla_kexts_loader = { path = "../build/kexts_loader" }

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -177,8 +177,7 @@ pub fn boot_kernel(#[cfg_attr(debug_assertions, allow(unused))] bootinfo: &BootI
     profiler.lap_time("kerla_api init");
 
     // Load kernel extensions.
-    info!("Initializing virtio_net...");
-    virtio_net::init();
+    kerla_kexts_loader::load_all();
     profiler.lap_time("kernel extensions init");
 
     // Initialize device drivers.

--- a/tools/generate-kexts-loader.py
+++ b/tools/generate-kexts-loader.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from pathlib import Path
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", help="The output directory.")
+    parser.add_argument("kexts", nargs="+", help="The list of kernel extensions (see kexts/*).")
+    args = parser.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    cargo_toml = """\
+[package]
+name = "kerla_kexts_loader"
+description = "Kerla kernel extensions loader. Automatically generated."
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+name = "kerla_kexts_loader"
+path = "lib.rs"
+
+[dependencies]
+log = "0"
+"""
+    lib_rs = """\
+#![no_std]
+
+pub fn load_all() {
+"""
+    for kext in args.kexts:
+        cargo_toml += f"{kext} = {{ path = \"{os.getcwd()}/exts/{kext}\" }}\n"
+        lib_rs += f"    log::info!(\"kext: loading {kext}\");\n"
+        lib_rs += f"    ::{kext}::init();\n"
+
+    lib_rs += """
+}
+"""
+
+    (Path(args.out_dir) / "Cargo.toml").write_text(cargo_toml)
+    (Path(args.out_dir) / "lib.rs").write_text(lib_rs)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
You can now specify the list of enabled kernel extensions through `$KEXTS` environment variable.