### PR TITLE
build: Add $(QEMU_ARGS) option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export GUI       ?=
 export RELEASE   ?=
 export ARCH      ?= x64
 export LOG       ?=
+export QEMU_ARGS ?=
 export KEXTS     ?= $(patsubst exts/%/Cargo.toml,%,$(wildcard exts/*/Cargo.toml))
 
 # The default build target.
@@ -119,7 +120,7 @@ run: build
 		$(if $(GDB),--gdb,)                                \
 		$(if $(LOG),--append-cmdline "log=$(LOG)",)        \
 		$(if $(QEMU),--qemu $(QEMU),)                      \
-		$(kernel_elf)
+		$(kernel_elf) -- $(QEMU_ARGS)
 
 .PHONY: bochs
 bochs: iso

--- a/tools/run-qemu.py
+++ b/tools/run-qemu.py
@@ -4,6 +4,7 @@ import shutil
 from tempfile import NamedTemporaryFile
 import os
 import subprocess
+import shlex
 import sys
 
 COMMON_ARGS = [
@@ -37,6 +38,7 @@ def main():
     parser.add_argument("--append-cmdline", action="append")
     parser.add_argument("--qemu")
     parser.add_argument("kernel_elf", help="The kernel ELF executable.")
+    parser.add_argument("qemu_args", nargs="*")
     args = parser.parse_args()
 
     if args.arch == "x64":
@@ -69,6 +71,8 @@ def main():
         argv += ["-accel", "kvm"]
     if args.append_cmdline is not None:
         argv += ["-append", " ".join(args.append_cmdline)]
+    if args.qemu_args:
+        argv += args.qemu_args
 
     p = subprocess.run(argv, preexec_fn=os.setsid)
     if p.returncode != 33:


### PR DESCRIPTION
Allow specifying extra QEMU options from the command-line.

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
