### PR TITLE
Support the secondary serial port for kernel messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # Default values for build system.
-export V         ?=
-export GUI       ?=
-export RELEASE   ?=
-export ARCH      ?= x64
-export LOG       ?=
-export QEMU_ARGS ?=
-export KEXTS     ?= $(patsubst exts/%/Cargo.toml,%,$(wildcard exts/*/Cargo.toml))
+export V          ?=
+export GUI        ?=
+export RELEASE    ?=
+export ARCH       ?= x64
+export LOG        ?=
+export LOG_SERIAL ?=
+export QEMU_ARGS  ?=
+export KEXTS      ?= $(patsubst exts/%/Cargo.toml,%,$(wildcard exts/*/Cargo.toml))
 
 # The default build target.
 .PHONY: default
@@ -113,13 +114,14 @@ iso: build
 
 .PHONY: run
 run: build
-	$(PYTHON3) tools/run-qemu.py                               \
-		--arch $(ARCH)                                     \
-		$(if $(GUI),--gui,)                                \
-		$(if $(KVM),--kvm,)                                \
-		$(if $(GDB),--gdb,)                                \
-		$(if $(LOG),--append-cmdline "log=$(LOG)",)        \
-		$(if $(QEMU),--qemu $(QEMU),)                      \
+	$(PYTHON3) tools/run-qemu.py                                           \
+		--arch $(ARCH)                                                 \
+		$(if $(GUI),--gui,)                                            \
+		$(if $(KVM),--kvm,)                                            \
+		$(if $(GDB),--gdb,)                                            \
+		$(if $(LOG),--append-cmdline "log=$(LOG)",)                    \
+		$(if $(LOG_SERIAL),--log-serial "$(LOG_SERIAL)",)              \
+		$(if $(QEMU),--qemu $(QEMU),)                                  \
 		$(kernel_elf) -- $(QEMU_ARGS)
 
 .PHONY: bochs

--- a/kernel/lang_items.rs
+++ b/kernel/lang_items.rs
@@ -14,7 +14,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     use core::sync::atomic::Ordering;
 
     if PANICKED.load(Ordering::SeqCst) {
-        kerla_runtime::print::print_bytes(b"double panic!\n");
+        kerla_runtime::print::get_debug_printer().print_bytes(b"\ndouble panic!\n");
         kerla_runtime::arch::halt();
     }
 

--- a/runtime/bootinfo.rs
+++ b/runtime/bootinfo.rs
@@ -17,4 +17,5 @@ pub struct BootInfo {
     pub virtio_mmio_devices: ArrayVec<VirtioMmioDevice, 4>,
     pub log_filter: ArrayString<64>,
     pub pci_enabled: bool,
+    pub use_second_serialport: bool,
 }

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -25,9 +25,9 @@ mod x64;
 
 pub mod arch {
     pub use super::x64::{
-        console_write, enable_irq, halt, idle, read_clock_counter, semihosting_halt, x64_specific,
-        Backtrace, PageFaultReason, PageTable, SavedInterruptStatus, SemihostingExitStatus,
-        SyscallFrame, KERNEL_BASE_ADDR, KERNEL_STRAIGHT_MAP_PADDR_END, PAGE_SIZE, TICK_HZ,
+        enable_irq, halt, idle, read_clock_counter, semihosting_halt, x64_specific, Backtrace,
+        PageFaultReason, PageTable, SavedInterruptStatus, SemihostingExitStatus, SyscallFrame,
+        KERNEL_BASE_ADDR, KERNEL_STRAIGHT_MAP_PADDR_END, PAGE_SIZE, TICK_HZ,
     };
 }
 

--- a/runtime/print.rs
+++ b/runtime/print.rs
@@ -3,10 +3,24 @@ use core::{fmt, str};
 use kerla_utils::static_cell::StaticCell;
 
 static PRINTER: StaticCell<&dyn Printer> = StaticCell::new(&NopPrinter);
+static DEBUG_PRINTER: StaticCell<&dyn Printer> = StaticCell::new(&NopPrinter);
 
-/// Sets the global log printer.
+pub fn get_printer() -> &'static dyn Printer {
+    PRINTER.load()
+}
+
+pub fn get_debug_printer() -> &'static dyn Printer {
+    DEBUG_PRINTER.load()
+}
+
+/// Sets the global log printer for user process output.
 pub fn set_printer(new_printer: &'static dyn Printer) {
     PRINTER.store(new_printer);
+}
+
+/// Sets the global log printer for log messages.
+pub fn set_debug_printer(new_printer: &'static dyn Printer) {
+    DEBUG_PRINTER.store(new_printer);
 }
 
 pub trait Printer: Sync {
@@ -31,13 +45,9 @@ pub struct PrinterWrapper;
 
 impl fmt::Write for PrinterWrapper {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        print_bytes(s.as_bytes());
+        get_debug_printer().print_bytes(s.as_bytes());
         Ok(())
     }
-}
-
-pub fn print_bytes(s: &[u8]) {
-    PRINTER.load().print_bytes(s);
 }
 
 /// Prints a string.

--- a/runtime/x64/boot.rs
+++ b/runtime/x64/boot.rs
@@ -84,7 +84,7 @@ unsafe extern "C" fn bsp_early_init(boot_magic: u32, boot_params: u64) -> ! {
 
     logger::set_log_filter(&boot_info.log_filter);
 
-    serial::init();
+    serial::init(boot_info.use_second_serialport);
     init_pic();
     common_setup(VAddr::new(&__bsp_cpu_local as *const _ as usize));
 

--- a/runtime/x64/bootinfo.rs
+++ b/runtime/x64/bootinfo.rs
@@ -128,6 +128,7 @@ struct Cmdline {
     pub pci_enabled: bool,
     pub virtio_mmio_devices: ArrayVec<VirtioMmioDevice, 4>,
     pub log_filter: ArrayString<64>,
+    pub use_second_serialport: bool,
 }
 
 impl Cmdline {
@@ -138,6 +139,7 @@ impl Cmdline {
         let mut pci_enabled = true;
         let mut virtio_mmio_devices = ArrayVec::new();
         let mut log_filter = ArrayString::new();
+        let mut use_second_serialport = false;
         if !s.is_empty() {
             for config in s.split(' ') {
                 let mut words = config.splitn(2, '=');
@@ -146,7 +148,12 @@ impl Cmdline {
                         warn!("bootinfo: PCI disabled");
                         pci_enabled = false;
                     }
+                    (Some("serial1"), Some("on")) => {
+                        info!("bootinfo: secondary serial port enabled");
+                        use_second_serialport = true;
+                    }
                     (Some("log"), Some(value)) => {
+                        info!("bootinfo: log filter = \"{}\"", value);
                         if log_filter.try_push_str(value).is_err() {
                             warn!("bootinfo: log filter is too long");
                         }
@@ -183,6 +190,7 @@ impl Cmdline {
             pci_enabled,
             virtio_mmio_devices,
             log_filter,
+            use_second_serialport,
         }
     }
 }
@@ -281,6 +289,7 @@ unsafe fn parse_multiboot2_info(header: &Multiboot2InfoHeader) -> BootInfo {
         pci_enabled: cmdline.pci_enabled,
         virtio_mmio_devices: cmdline.virtio_mmio_devices,
         log_filter: cmdline.log_filter,
+        use_second_serialport: cmdline.use_second_serialport,
     }
 }
 
@@ -321,6 +330,7 @@ unsafe fn parse_multiboot_legacy_info(info: &MultibootLegacyInfo) -> BootInfo {
         pci_enabled: cmdline.pci_enabled,
         virtio_mmio_devices: cmdline.virtio_mmio_devices,
         log_filter: cmdline.log_filter,
+        use_second_serialport: cmdline.use_second_serialport,
     }
 }
 
@@ -351,6 +361,7 @@ unsafe fn parse_linux_boot_params(boot_params: PAddr) -> BootInfo {
         pci_enabled: cmdline.pci_enabled,
         virtio_mmio_devices: cmdline.virtio_mmio_devices,
         log_filter: cmdline.log_filter,
+        use_second_serialport: cmdline.use_second_serialport,
     }
 }
 

--- a/runtime/x64/interrupt.rs
+++ b/runtime/x64/interrupt.rs
@@ -1,6 +1,6 @@
 use crate::{address::UserVAddr, handler};
 
-use super::{apic::ack_interrupt, ioapic::VECTOR_IRQ_BASE, serial::SERIAL_IRQ, PageFaultReason};
+use super::{apic::ack_interrupt, ioapic::VECTOR_IRQ_BASE, serial::SERIAL0_IRQ, PageFaultReason};
 use x86::{
     controlregs::cr2,
     current::rflags::{self, RFlags},
@@ -72,8 +72,8 @@ unsafe extern "C" fn x64_handle_interrupt(vec: u8, frame: *const InterruptFrame)
                 TIMER_IRQ | TIMER_IRQ2 => {
                     handler().handle_timer_irq();
                 }
-                SERIAL_IRQ => {
-                    super::serial::irq_handler();
+                SERIAL0_IRQ => {
+                    super::serial::serial0_irq_handler();
                 }
                 _ => {
                     handler().handle_irq(irq);

--- a/runtime/x64/mod.rs
+++ b/runtime/x64/mod.rs
@@ -30,7 +30,6 @@ pub use ioapic::enable_irq;
 pub use paging::{PageFaultReason, PageTable};
 pub use profile::read_clock_counter;
 pub use semihosting::{semihosting_halt, SemihostingExitStatus};
-pub use serial::console_write;
 pub use syscall::SyscallFrame;
 
 pub mod x64_specific {

--- a/runtime/x64/serial.rs
+++ b/runtime/x64/serial.rs
@@ -1,14 +1,18 @@
+//! A serial port driver. See https://wiki.osdev.org/Serial_Ports
 use x86::io::{inb, outb};
 
 use crate::{
     handler,
-    print::{set_printer, Printer},
+    print::{set_debug_printer, set_printer, Printer},
 };
 
 use super::{ioapic::enable_irq, vga};
 
-pub const SERIAL_IRQ: u8 = 4;
-const IOPORT_SERIAL: u16 = 0x3f8;
+pub const SERIAL0_IOPORT: u16 = 0x3f8;
+pub const SERIAL1_IOPORT: u16 = 0x2f8;
+pub const SERIAL0_IRQ: u8 = 4;
+pub const SERIAL1_IRQ: u8 = 3;
+const THR: u16 = 0;
 const DLL: u16 = 0;
 const RBR: u16 = 0;
 const DLH: u16 = 1;
@@ -18,47 +22,92 @@ const LCR: u16 = 3;
 const LSR: u16 = 5;
 const TX_READY: u8 = 0x20;
 
-unsafe fn serial_write(ch: u8) {
-    while (inb(IOPORT_SERIAL + LSR) & TX_READY) == 0 {}
-    outb(IOPORT_SERIAL, ch);
+struct SerialPort {
+    ioport_base: u16,
+    irq: u8,
 }
 
-pub fn printchar(ch: u8) {
-    unsafe {
+impl SerialPort {
+    pub const fn new(ioport_base: u16, irq: u8) -> SerialPort {
+        SerialPort { ioport_base, irq }
+    }
+
+    pub fn initialize(&self) {
+        let divisor: u16 = 12; // 115200 / 9600 = 12
+        unsafe {
+            self.outb(IER, 0x00); // Disable interrupts.
+            self.outb(DLL, (divisor & 0xff) as u8);
+            self.outb(DLH, ((divisor >> 8) & 0xff) as u8);
+            self.outb(LCR, 0x03); // 8n1.
+            self.outb(FCR, 0x01); // Enable FIFO.
+            self.outb(IER, 0x01); // Enable interrupts.
+        }
+    }
+
+    pub fn irq(&self) -> u8 {
+        self.irq
+    }
+
+    pub fn print_char(&self, ch: u8) {
         if ch == b'\n' && option_env!("DISABLE_AUTO_CR_PRINT").is_none() {
-            serial_write(b'\r');
+            self.send_char(b'\r');
         }
-        serial_write(ch);
+        self.send_char(ch);
+    }
+
+    pub fn send_char(&self, ch: u8) {
+        unsafe {
+            while (self.inb(LSR) & TX_READY) == 0 {}
+            self.outb(THR, ch);
+        }
+    }
+
+    pub fn receive_char(&self) -> Option<u8> {
+        unsafe {
+            if (self.inb(LSR) & 1) == 0 {
+                return None;
+            }
+
+            Some(self.inb(RBR))
+        }
+    }
+
+    unsafe fn inb(&self, port: u16) -> u8 {
+        inb(self.ioport_base + port)
+    }
+
+    unsafe fn outb(&self, port: u16, data: u8) {
+        outb(self.ioport_base + port, data);
     }
 }
 
-pub fn console_write(s: &[u8]) {
-    for ch in s {
-        printchar(*ch);
-        vga::printchar(*ch);
-    }
-}
+static SERIAL0: SerialPort = SerialPort::new(SERIAL0_IOPORT, SERIAL0_IRQ);
+static SERIAL1: SerialPort = SerialPort::new(SERIAL1_IOPORT, SERIAL1_IRQ);
 
-struct SerialPrinter;
+struct Serial0Printer;
 
-impl Printer for SerialPrinter {
+impl Printer for Serial0Printer {
     fn print_bytes(&self, s: &[u8]) {
-        console_write(s);
-    }
-}
-
-fn read_char() -> Option<u8> {
-    unsafe {
-        if (inb(IOPORT_SERIAL + LSR) & 1) == 0 {
-            return None;
+        for ch in s {
+            SERIAL0.print_char(*ch);
+            vga::printchar(*ch);
         }
-
-        Some(inb(IOPORT_SERIAL + RBR))
     }
 }
 
-pub fn irq_handler() {
-    while let Some(ch) = read_char() {
+struct Serial1Printer;
+
+impl Printer for Serial1Printer {
+    fn print_bytes(&self, s: &[u8]) {
+        for ch in s {
+            SERIAL1.print_char(*ch);
+            vga::printchar(*ch);
+        }
+    }
+}
+
+pub fn serial0_irq_handler() {
+    while let Some(ch) = SERIAL0.receive_char() {
         if ch == b'\r' {
             handler().handle_console_rx(b'\n');
         } else {
@@ -68,18 +117,18 @@ pub fn irq_handler() {
 }
 
 pub unsafe fn early_init() {
-    let divisor: u16 = 12; // 115200 / 9600 = 12
-    outb(IOPORT_SERIAL + IER, 0x00); // Disable interrupts.
-    outb(IOPORT_SERIAL + DLL, (divisor & 0xff) as u8);
-    outb(IOPORT_SERIAL + DLH, ((divisor >> 8) & 0xff) as u8);
-    outb(IOPORT_SERIAL + LCR, 0x03); // 8n1.
-    outb(IOPORT_SERIAL + FCR, 0x01); // Enable FIFO.
-    outb(IOPORT_SERIAL + IER, 0x01); // Enable interrupts.
+    SERIAL0.initialize();
+    set_printer(&Serial0Printer);
+    set_debug_printer(&Serial0Printer);
 
-    set_printer(&SerialPrinter);
-    printchar(b'\n');
+    SERIAL0.print_char(b'\n');
 }
 
-pub fn init() {
-    enable_irq(4);
+pub fn init(use_second_serialport: bool) {
+    enable_irq(SERIAL0.irq());
+
+    if use_second_serialport {
+        SERIAL1.initialize();
+        set_debug_printer(&Serial1Printer);
+    }
 }

--- a/tools/run-qemu.py
+++ b/tools/run-qemu.py
@@ -36,6 +36,7 @@ def main():
     parser.add_argument("--gdb", action="store_true")
     parser.add_argument("--kvm", action="store_true")
     parser.add_argument("--append-cmdline", action="append")
+    parser.add_argument("--log-serial")
     parser.add_argument("--qemu")
     parser.add_argument("kernel_elf", help="The kernel ELF executable.")
     parser.add_argument("qemu_args", nargs="*")
@@ -63,16 +64,23 @@ def main():
         qemu_bin = qemu["bin"]
 
     argv = [qemu_bin] + qemu["args"] + ["-kernel", kernel_elf]
+    cmdline = []
     if not args.gui:
         argv += ["-nographic"]
     if args.gdb:
         argv += ["-gdb", "tcp::7789", "-S"]
     if args.kvm:
         argv += ["-accel", "kvm"]
-    if args.append_cmdline is not None:
-        argv += ["-append", " ".join(args.append_cmdline)]
+    if args.append_cmdline:
+        cmdline += args.append_cmdline
+    if args.log_serial:
+        argv += ["-serial", args.log_serial]
+        cmdline += ["serial1=on"]
     if args.qemu_args:
         argv += args.qemu_args
+
+    if cmdline:
+        argv += ["-append", " ".join(cmdline)]
 
     p = subprocess.run(argv, preexec_fn=os.setsid)
     if p.returncode != 33:


### PR DESCRIPTION
Allow redirecting kernel messages to the secondary serial port thorugh $(LOG_SERIAL):

```
$ make run LOG=trace LOG_SERIAL="chardev:uart1" QEMU_ARGS="-chardev file,id=uart1,path=/tmp/kerla-debug.log,logappend=on"
```

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
