### PR TITLE
x64: Make SyscallFrame compatible with Linux's struct pt_regs

### DIFF
--- a/kernel/arch/x64/process.rs
+++ b/kernel/arch/x64/process.rs
@@ -6,7 +6,7 @@ use crossbeam::atomic::AtomicCell;
 use kerla_runtime::address::{UserVAddr, VAddr};
 use kerla_runtime::{
     arch::x64_specific::{cpu_local_head, TSS, USER_CS64, USER_DS, USER_RPL},
-    arch::SyscallFrame,
+    arch::PtRegs,
     arch::PAGE_SIZE,
     page_allocator::{alloc_pages, AllocPageFlags},
 };
@@ -135,7 +135,7 @@ impl Process {
         }
     }
 
-    pub fn fork(&self, frame: &SyscallFrame) -> Result<Process> {
+    pub fn fork(&self, frame: &PtRegs) -> Result<Process> {
         // TODO: Check the size of XSAVE area.
         let xsave_area = alloc_pages(1, AllocPageFlags::KERNEL)
             .expect("failed to allocate xsave area")
@@ -194,7 +194,7 @@ impl Process {
 
     pub fn setup_execve_stack(
         &self,
-        frame: &mut SyscallFrame,
+        frame: &mut PtRegs,
         ip: UserVAddr,
         user_sp: UserVAddr,
     ) -> Result<()> {
@@ -205,7 +205,7 @@ impl Process {
 
     pub unsafe fn setup_signal_stack(
         &self,
-        frame: &mut SyscallFrame,
+        frame: &mut PtRegs,
         signal: Signal,
         sa_handler: UserVAddr,
     ) -> Result<()> {
@@ -242,11 +242,7 @@ impl Process {
         Ok(())
     }
 
-    pub fn setup_sigreturn_stack(
-        &self,
-        current_frame: &mut SyscallFrame,
-        signaled_frame: &SyscallFrame,
-    ) {
+    pub fn setup_sigreturn_stack(&self, current_frame: &mut PtRegs, signaled_frame: &PtRegs) {
         *current_frame = *signaled_frame;
     }
 }

--- a/kernel/arch/x64/usermode.S
+++ b/kernel/arch/x64/usermode.S
@@ -27,21 +27,24 @@ syscall_entry:
     mov gs:[GS_RSP3], rsp
     mov rsp, gs:[GS_RSP0]
 
-    // Start accepting interrupts.
-    // sti FIXME:
-
-    // Save SYSRET context and registers onto the kernel stack.
+    // Save SYSRET context and registers (pt_regs) onto the kernel stack.
+    push 32           // User SS (USER_DS). FIXME: Hardcoded.
     push gs:[GS_RSP3] // User RSP.
-    push r11 // User RFLAGS.
-    push rcx // User RIP.
-    push rbp
-    push rbx
-    push rdx
+    push r11          // User RFLAGS.
+    push 40           // User CS (USER_CS64). FIXME: Hardcoded.
+    push rcx          // User RIP.
+    push rax          // orig_rax
     push rdi
     push rsi
+    push rdx
+    push rcx
+    push 0            // User RAX.
     push r8
     push r9
     push r10
+    push r11
+    push rbx
+    push rbp
     push r12
     push r13
     push r14
@@ -58,16 +61,21 @@ syscall_entry:
     pop r14
     pop r13
     pop r12
+    pop rbp
+    pop rbx
+    pop r11
     pop r10
     pop r9
     pop r8
+    add rsp, 16 // User RAX & RCX
+    pop rdx
     pop rsi
     pop rdi
-    pop rdx
-    pop rbx
-    pop rbp
-    pop rcx
-    pop r11
+    add rsp, 8 // orig_rax
+    pop rcx    // User RIP
+    add rsp, 8 // User CS
+    pop r11    // User RFLAGS
+
     pop rsp
 
     // Ensure that interrupts are disabled since SWAPGS and SYSRETQ are not a

--- a/kernel/arch/x64/usermode.S
+++ b/kernel/arch/x64/usermode.S
@@ -38,7 +38,7 @@ syscall_entry:
     push rsi
     push rdx
     push rcx
-    push 0            // User RAX.
+    push rax          // User RAX.
     push r8
     push r9
     push r10

--- a/kernel/arch/x64/usermode.S
+++ b/kernel/arch/x64/usermode.S
@@ -63,7 +63,7 @@ syscall_entry:
     pop r12
     pop rbp
     pop rbx
-    pop r11
+    add rsp, 8 // User R11
     pop r10
     pop r9
     pop r8

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -61,7 +61,7 @@ use alloc::{boxed::Box, sync::Arc};
 use interrupt::attach_irq;
 use kerla_api::kernel_ops::KernelOps;
 use kerla_runtime::{
-    arch::{idle, PageFaultReason, SyscallFrame},
+    arch::{idle, PageFaultReason, PtRegs},
     bootinfo::BootInfo,
     profile::StopWatch,
     spinlock::SpinLock,
@@ -106,7 +106,7 @@ impl kerla_runtime::Handler for Handler {
         a5: usize,
         a6: usize,
         n: usize,
-        frame: *mut SyscallFrame,
+        frame: *mut PtRegs,
     ) -> isize {
         let mut handler = SyscallHandler::new(unsafe { &mut *frame });
         handler

--- a/kernel/syscalls/mod.rs
+++ b/kernel/syscalls/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     user_buffer::UserCStr,
 };
 use bitflags::bitflags;
-use kerla_runtime::{address::UserVAddr, arch::SyscallFrame};
+use kerla_runtime::{address::UserVAddr, arch::PtRegs};
 
 pub(self) mod accept;
 pub(self) mod arch_prctl;
@@ -168,11 +168,11 @@ fn resolve_path(uaddr: usize) -> Result<PathBuf> {
 }
 
 pub struct SyscallHandler<'a> {
-    pub frame: &'a mut SyscallFrame,
+    pub frame: &'a mut PtRegs,
 }
 
 impl<'a> SyscallHandler<'a> {
-    pub fn new(frame: &'a mut SyscallFrame) -> SyscallHandler<'a> {
+    pub fn new(frame: &'a mut PtRegs) -> SyscallHandler<'a> {
         SyscallHandler { frame }
     }
 

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -26,7 +26,7 @@ mod x64;
 pub mod arch {
     pub use super::x64::{
         enable_irq, halt, idle, read_clock_counter, semihosting_halt, x64_specific, Backtrace,
-        PageFaultReason, PageTable, SavedInterruptStatus, SemihostingExitStatus, SyscallFrame,
+        PageFaultReason, PageTable, PtRegs, SavedInterruptStatus, SemihostingExitStatus,
         KERNEL_BASE_ADDR, KERNEL_STRAIGHT_MAP_PADDR_END, PAGE_SIZE, TICK_HZ,
     };
 }
@@ -55,7 +55,7 @@ pub trait Handler: Sync {
         a5: usize,
         a6: usize,
         n: usize,
-        frame: *mut arch::SyscallFrame,
+        frame: *mut arch::PtRegs,
     ) -> isize;
 
     #[cfg(debug_assertions)]
@@ -88,7 +88,7 @@ impl Handler for NopHandler {
         _a5: usize,
         _a6: usize,
         _n: usize,
-        _frame: *mut x64::SyscallFrame,
+        _frame: *mut x64::PtRegs,
     ) -> isize {
         0
     }

--- a/runtime/x64/gdt.rs
+++ b/runtime/x64/gdt.rs
@@ -5,8 +5,8 @@ use x86::dtables::{lgdt, DescriptorTablePointer};
 
 pub const KERNEL_CS: u16 = 8;
 pub const USER_CS32: u16 = 24;
-pub const USER_DS: u16 = 32;
-pub const USER_CS64: u16 = 40;
+pub const USER_DS: u16 = 32; // Note: it's hard coded in kernel's usermode.S
+pub const USER_CS64: u16 = 40; // Note: it's hard coded in kernel's usermode.S
 pub const TSS_SEG: u16 = 48;
 pub const USER_RPL: u16 = 3;
 

--- a/runtime/x64/mod.rs
+++ b/runtime/x64/mod.rs
@@ -30,7 +30,7 @@ pub use ioapic::enable_irq;
 pub use paging::{PageFaultReason, PageTable};
 pub use profile::read_clock_counter;
 pub use semihosting::{semihosting_halt, SemihostingExitStatus};
-pub use syscall::SyscallFrame;
+pub use syscall::PtRegs;
 
 pub mod x64_specific {
     pub use super::cpu_local::cpu_local_head;

--- a/runtime/x64/syscall.rs
+++ b/runtime/x64/syscall.rs
@@ -9,22 +9,28 @@ const SYSCALL_RFLAGS_MASK: u64 = 0x200;
 
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
-pub struct SyscallFrame {
+pub struct PtRegs {
     pub r15: u64,
     pub r14: u64,
     pub r13: u64,
     pub r12: u64,
+    pub rbp: u64,
+    pub rbx: u64,
+    pub r11: u64,
     pub r10: u64,
     pub r9: u64,
     pub r8: u64,
+    pub rax: u64,
+    pub rcx: u64,
+    pub rdx: u64,
     pub rsi: u64,
     pub rdi: u64,
-    pub rdx: u64,
-    pub rbx: u64,
-    pub rbp: u64,
+    pub orig_rax: u64,
     pub rip: u64,
+    pub cs: u64,
     pub rflags: u64,
     pub rsp: u64,
+    pub ss: u64,
 }
 
 #[no_mangle]
@@ -36,7 +42,7 @@ extern "C" fn x64_handle_syscall(
     a5: usize,
     a6: usize,
     n: usize,
-    frame: *mut SyscallFrame,
+    frame: *mut PtRegs,
 ) -> isize {
     handler().handle_syscall(a1, a2, a3, a4, a5, a6, n, frame)
 }


### PR DESCRIPTION
<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
