### PR TITLE
rt_sigprocmask syscall implementation

### DIFF
--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -387,7 +387,6 @@ impl Process {
     /// If there's a pending signal, it may modify `frame` (e.g. user return
     /// address and stack pointer) to call the registered user's signal handler.
     pub fn try_delivering_signal(frame: &mut PtRegs) -> Result<()> {
-        // TODO: sigmask
         let current = current_process();
         if let Some((signal, sigaction)) = current.signals.lock().pop_pending() {
             let sigset = current.sigset.lock();

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -356,7 +356,7 @@ impl Process {
         self.signals.lock().is_pending()
     }
 
-    /// Sets signal mask
+    /// Sets signal mask.
     pub fn set_signal_mask(
         &self,
         how: SignalMask,

--- a/kernel/process/signal.rs
+++ b/kernel/process/signal.rs
@@ -156,3 +156,8 @@ impl SignalDelivery {
 }
 
 pub type SigSet = BitMap<128 /* 1024 / 8 */>;
+pub enum SignalMask {
+    Block,
+    Unblock,
+    Set,
+}

--- a/kernel/process/signal.rs
+++ b/kernel/process/signal.rs
@@ -1,5 +1,6 @@
 use crate::{ctypes::c_int, prelude::*};
 use kerla_runtime::address::UserVAddr;
+use kerla_utils::bitmap::BitMap;
 
 pub type Signal = c_int;
 #[allow(unused)]
@@ -153,3 +154,5 @@ impl SignalDelivery {
         self.pending |= 1 << (signal);
     }
 }
+
+pub type SigSet = BitMap<128 /* 1024 / 8 */>;

--- a/kernel/syscalls/mod.rs
+++ b/kernel/syscalls/mod.rs
@@ -57,6 +57,7 @@ pub(self) mod readlink;
 pub(self) mod reboot;
 pub(self) mod recvfrom;
 pub(self) mod rt_sigaction;
+pub(self) mod rt_sigprocmask;
 pub(self) mod rt_sigreturn;
 pub(self) mod select;
 pub(self) mod sendto;
@@ -112,6 +113,7 @@ const SYS_POLL: usize = 7;
 const SYS_MMAP: usize = 9;
 const SYS_BRK: usize = 12;
 const SYS_RT_SIGACTION: usize = 13;
+const SYS_RT_SIGPROCMASK: usize = 14;
 const SYS_RT_SIGRETURN: usize = 15;
 const SYS_IOCTL: usize = 16;
 const SYS_WRITEV: usize = 20;
@@ -368,6 +370,9 @@ impl<'a> SyscallHandler<'a> {
             SYS_SYSLOG => self.sys_syslog(a1 as c_int, UserVAddr::new(a2), a3 as c_int),
             SYS_REBOOT => self.sys_reboot(a1 as c_int, a2 as c_int, a3),
             SYS_GETTID => self.sys_gettid(),
+            SYS_RT_SIGPROCMASK => {
+                self.sys_rt_sigprocmask(a1, UserVAddr::new(a2), UserVAddr::new(a3), a4)
+            }
             _ => {
                 debug_warn!(
                     "unimplemented system call: {} (n={})",

--- a/kernel/syscalls/rt_sigprocmask.rs
+++ b/kernel/syscalls/rt_sigprocmask.rs
@@ -13,6 +13,10 @@ impl SyscallHandler<'_> {
         oldset: Option<UserVAddr>,
         length: usize,
     ) -> Result<isize> {
+        if length != 8{
+            debug_warn!("sys_rt_sigprocmask length argument is not equal 8");
+        }
+        
         let how = match how {
             0 => SignalMask::Block,
             1 => SignalMask::Unblock,

--- a/kernel/syscalls/rt_sigprocmask.rs
+++ b/kernel/syscalls/rt_sigprocmask.rs
@@ -19,7 +19,11 @@ impl SyscallHandler<'_> {
             2 => SignalMask::Set,
             _ => return Err(Errno::EINVAL.into()),
         };
-        current_process().set_signal_mask(how, set, oldset, length)?;
+
+        if let Err(_) = current_process().set_signal_mask(how, set, oldset, length) {
+            return Err(Errno::EFAULT.into());
+        }
+
         Ok(0)
     }
 }

--- a/kernel/syscalls/rt_sigprocmask.rs
+++ b/kernel/syscalls/rt_sigprocmask.rs
@@ -1,0 +1,17 @@
+use crate::prelude::*;
+use crate::process::current_process;
+
+use crate::syscalls::SyscallHandler;
+use kerla_runtime::address::UserVAddr;
+
+impl SyscallHandler<'_> {
+    pub fn sys_rt_sigprocmask(
+        &mut self,
+        how: usize,
+        set: Option<UserVAddr>,
+        oldset: Option<UserVAddr>,
+        length: usize,
+    ) -> Result<isize> {
+        current_process().rt_sigprocmask(how, set, oldset, length)
+    }
+}

--- a/kernel/syscalls/rt_sigprocmask.rs
+++ b/kernel/syscalls/rt_sigprocmask.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::process::current_process;
 
+use crate::process::signal::SignalMask;
 use crate::syscalls::SyscallHandler;
 use kerla_runtime::address::UserVAddr;
 
@@ -12,6 +13,13 @@ impl SyscallHandler<'_> {
         oldset: Option<UserVAddr>,
         length: usize,
     ) -> Result<isize> {
-        current_process().rt_sigprocmask(how, set, oldset, length)
+        let how = match how {
+            0 => SignalMask::Block,
+            1 => SignalMask::Unblock,
+            2 => SignalMask::Set,
+            _ => return Err(Errno::EINVAL.into()),
+        };
+        current_process().set_signal_mask(how, set, oldset, length)?;
+        Ok(0)
     }
 }

--- a/libs/kerla_utils/bitmap.rs
+++ b/libs/kerla_utils/bitmap.rs
@@ -1,5 +1,6 @@
 use core::slice::memchr::memchr;
 
+#[derive(Clone)]
 pub struct BitMap<const SZ: usize>([u8; SZ]);
 
 impl<const SZ: usize> BitMap<SZ> {
@@ -55,24 +56,18 @@ impl<const SZ: usize> BitMap<SZ> {
         self.0 = rhs;
     }
 
+    /// This method will panic if SZ != rhs.len()
     pub fn assign_or(&mut self, rhs: [u8; SZ]) {
-        let mut iter = rhs.into_iter();
-        for byte in &mut self.0 {
-            *byte |= iter.next().unwrap_or(0);
+        for (i, byte) in self.0.iter_mut().enumerate() {
+            *byte |= rhs[i];
         }
     }
 
-    pub fn assign_material_nonimplication(&mut self, rhs: [u8; SZ]) {
-        let mut iter = rhs.into_iter();
-        for byte in &mut self.0 {
-            *byte &= !iter.next().unwrap_or(0);
+    /// This method will panic if SZ != rhs.len()
+    pub fn assign_and_not(&mut self, rhs: [u8; SZ]) {
+        for (i, byte) in self.0.iter_mut().enumerate() {
+            *byte &= !rhs[i];
         }
-    }
-}
-
-impl<const SZ: usize> Clone for BitMap<SZ> {
-    fn clone(&self) -> Self {
-        BitMap(self.0)
     }
 }
 
@@ -105,7 +100,7 @@ mod tests {
     #[test]
     fn material_nonimplication() {
         let mut bitmap = BitMap::from_array([0b0100_0010, 0b1000_0001]);
-        bitmap.assign_material_nonimplication([0b0110_0100, 0b1010_0110]);
+        bitmap.assign_and_not([0b0110_0100, 0b1010_0110]);
         assert_eq!(bitmap.as_slice(), &[0b0000_0010, 0b0000_0001]);
     }
 }

--- a/libs/kerla_utils/bitmap.rs
+++ b/libs/kerla_utils/bitmap.rs
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn material_nonimplication() {
+    fn assign_and_not() {
         let mut bitmap = BitMap::from_array([0b0100_0010, 0b1000_0001]);
         bitmap.assign_and_not([0b0110_0100, 0b1010_0110]);
         assert_eq!(bitmap.as_slice(), &[0b0000_0010, 0b0000_0001]);


### PR DESCRIPTION
This pull request adds rt_sigprocmask syscall handler (https://man7.org/linux/man-pages/man2/sigprocmask.2.html). 

Before adding signal filtering, I want to discuss the general approach. 

Things that bother me: 

I feel like the `how` argument should be an enum, but how to handle `EINVAL` in that case?

And the `length` argument doesn't make any sense to me. According to the manual, it is `sizeof(kernel_sigset_t)`, and according to kernel sources, `kernel_sigset_t` is 1024 bits. So it always, according to POSIX, should be 128 bytes, unless we will run on something exotic like PDP-6/10 or DSP. If you can point me to some document or discussion to make sense of it, I would be grateful. 

Also `set` and `oldset` are 1024 bits in length. I am using a slightly modified BitMap from kerla_utils, but it is suboptimal. It is [u8;128], which means we have 128 iterations on `SIG_BLOCK` and `SIG_UNBLOCK`. The solution can be generic over the type BitMap. Or create a new LongBitMap, which will use u128 under the hood. Or, maybe we can use or take inspiration from something like https://docs.rs/bitmaps/latest/bitmaps/. But I have a feeling that this is a task by itself, and should be discussed in a separate issue/PR.

 


