### PR TITLE
#112 followup (bugfix and fix build)

### DIFF
--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -38,7 +38,7 @@ use kerla_runtime::{
 };
 use kerla_utils::{alignment::align_up, bitmap::BitMap};
 
-use super::signal::SigSet;
+use super::signal::{SigSet, EXCLUDING_SIGNAL_MASK};
 
 type ProcessTable = BTreeMap<PId, Arc<Process>>;
 
@@ -373,7 +373,10 @@ impl Process {
         if let Some(new) = set {
             let new_set = new.read::<[u8; 128]>()?;
             match how {
-                SignalMask::Block => sigset.assign_or(new_set),
+                SignalMask::Block => {
+                    sigset.assign_or(new_set);
+                    sigset.assign_and_not(EXCLUDING_SIGNAL_MASK);
+                }
                 SignalMask::Unblock => sigset.assign_and_not(new_set),
                 SignalMask::Set => sigset.assign(new_set),
             }

--- a/kernel/process/signal.rs
+++ b/kernel/process/signal.rs
@@ -156,15 +156,6 @@ impl SignalDelivery {
 }
 
 pub type SigSet = BitMap<128 /* 1024 / 8 */>;
-// Bits 9 (SIGKILL) and 19 (SIGSTOP) are set because of
-// "It is not possible to block SIGKILL or SIGSTOP.  Attempts to do so are silently ignored."
-// https://man7.org/linux/man-pages/man2/sigprocmask.2.html
-pub const EXCLUDING_SIGNAL_MASK: [u8; 128] = [
-    0, 2, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-];
 pub enum SignalMask {
     Block,
     Unblock,

--- a/kernel/process/signal.rs
+++ b/kernel/process/signal.rs
@@ -156,6 +156,15 @@ impl SignalDelivery {
 }
 
 pub type SigSet = BitMap<128 /* 1024 / 8 */>;
+// Bits 9 (SIGKILL) and 19 (SIGSTOP) are set because of
+// "It is not possible to block SIGKILL or SIGSTOP.  Attempts to do so are silently ignored."
+// https://man7.org/linux/man-pages/man2/sigprocmask.2.html
+pub const EXCLUDING_SIGNAL_MASK: [u8; 128] = [
+    0, 2, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
 pub enum SignalMask {
     Block,
     Unblock,

--- a/kernel/syscalls/rt_sigprocmask.rs
+++ b/kernel/syscalls/rt_sigprocmask.rs
@@ -13,10 +13,10 @@ impl SyscallHandler<'_> {
         oldset: Option<UserVAddr>,
         length: usize,
     ) -> Result<isize> {
-        if length != 8{
+        if length != 8 {
             debug_warn!("sys_rt_sigprocmask length argument is not equal 8");
         }
-        
+
         let how = match how {
             0 => SignalMask::Block,
             1 => SignalMask::Unblock,
@@ -24,9 +24,7 @@ impl SyscallHandler<'_> {
             _ => return Err(Errno::EINVAL.into()),
         };
 
-        if let Err(_) = current_process().set_signal_mask(how, set, oldset, length) {
-            return Err(Errno::EFAULT.into());
-        }
+        current_process().set_signal_mask(how, set, oldset, length)?;
 
         Ok(0)
     }


### PR DESCRIPTION
This is #112 follow-up with two changes:

1. We missed this part: "It is not possible to block SIGKILL or SIGSTOP.  Attempts to do so are silently ignored." (https://man7.org/linux/man-pages/man2/sigprocmask.2.html) addressing that
2.  Fixing Clippy issue: 
```sh
error: redundant pattern matching, consider using `is_err()`
  --> kernel/syscalls/rt_sigprocmask.rs:27:16
   |
27 |         if let Err(_) = current_process().set_signal_mask(how, set, oldset, length) {
   |         -------^^^^^^-------------------------------------------------------------- help: try this: `if current_process().set_signal_mask(how, set, oldset, length).is_err()`
   |
   = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
```
which we introduced in #112 