### PR TITLE
Implement shutdown(2)

### DIFF
--- a/kernel/fs/inode.rs
+++ b/kernel/fs/inode.rs
@@ -89,6 +89,11 @@ pub trait FileLike: Debug + Send + Sync + Downcastable {
         Err(Error::new(Errno::EBADF))
     }
 
+    /// `shutdown(2)`.
+    fn shutdown(&self, _how: ShutdownHow) -> Result<()> {
+        Err(Error::new(Errno::EBADF))
+    }
+
     /// `listen(2)`.
     fn listen(&self, _backlog: i32) -> Result<()> {
         Err(Error::new(Errno::EBADF))

--- a/kernel/fs/opened_file.rs
+++ b/kernel/fs/opened_file.rs
@@ -236,6 +236,10 @@ impl OpenedFile {
         self.as_file()?.bind(sockaddr)
     }
 
+    pub fn shutdown(&self, how: ShutdownHow) -> Result<()> {
+        self.as_file()?.shutdown(how)
+    }
+
     pub fn getsockname(&self) -> Result<SockAddr> {
         self.as_file()?.getsockname()
     }

--- a/kernel/net/socket.rs
+++ b/kernel/net/socket.rs
@@ -32,6 +32,17 @@ pub type sa_family_t = u16;
 #[allow(non_camel_case_types)]
 pub type socklen_t = u32;
 
+/// The `how` argument in `shutdown(2)`.
+#[repr(i32)]
+pub enum ShutdownHow {
+    /// `SHUT_RD`.
+    Rd = 0,
+    /// `SHUT_WR`.
+    Wr = 1,
+    /// `SHUT_RDWR`.
+    RdWr = 2,
+}
+
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum SockAddr {

--- a/kernel/net/tcp_socket.rs
+++ b/kernel/net/tcp_socket.rs
@@ -121,6 +121,16 @@ impl FileLike for TcpSocket {
         Ok(())
     }
 
+    fn shutdown(&self, _how: super::ShutdownHow) -> Result<()> {
+        SOCKETS
+            .lock()
+            .get::<smoltcp::socket::TcpSocket>(self.handle)
+            .close();
+
+        process_packets();
+        Ok(())
+    }
+
     fn getsockname(&self) -> Result<SockAddr> {
         let endpoint = SOCKETS
             .lock()

--- a/kernel/syscalls/mod.rs
+++ b/kernel/syscalls/mod.rs
@@ -63,6 +63,7 @@ pub(self) mod select;
 pub(self) mod sendto;
 pub(self) mod set_tid_address;
 pub(self) mod setpgid;
+pub(self) mod shutdown;
 pub(self) mod socket;
 pub(self) mod stat;
 pub(self) mod syslog;
@@ -126,6 +127,7 @@ const SYS_CONNECT: usize = 42;
 const SYS_ACCEPT: usize = 43;
 const SYS_SENDTO: usize = 44;
 const SYS_RECVFROM: usize = 45;
+const SYS_SHUTDOWN: usize = 48;
 const SYS_BIND: usize = 49;
 const SYS_LISTEN: usize = 50;
 const SYS_GETSOCKNAME: usize = 51;
@@ -318,6 +320,7 @@ impl<'a> SyscallHandler<'a> {
             SYS_EXIT => self.sys_exit(a1 as i32),
             SYS_SOCKET => self.sys_socket(a1 as i32, a2 as i32, a3 as i32),
             SYS_BIND => self.sys_bind(Fd::new(a1 as i32), UserVAddr::new_nonnull(a2)?, a3 as usize),
+            SYS_SHUTDOWN => self.sys_shutdown(Fd::new(a1 as i32), a2 as i32),
             SYS_CONNECT => {
                 self.sys_connect(Fd::new(a1 as i32), UserVAddr::new_nonnull(a2)?, a3 as usize)
             }

--- a/kernel/syscalls/shutdown.rs
+++ b/kernel/syscalls/shutdown.rs
@@ -5,7 +5,7 @@ use crate::result::Result;
 use crate::{process::current_process, syscalls::SyscallHandler};
 
 impl<'a> SyscallHandler<'a> {
-    pub fn sys_shutdown(&mut self, fd: Fd, how: c_int) -> Result<isize> {
+    pub fn sys_shutdown(&mut self, fd: Fd, _how: c_int) -> Result<isize> {
         let opened_file = current_process().get_opened_file_by_fd(fd)?;
         opened_file.shutdown(ShutdownHow::RdWr /* FIXME: */)?;
         Ok(0)

--- a/kernel/syscalls/shutdown.rs
+++ b/kernel/syscalls/shutdown.rs
@@ -1,0 +1,13 @@
+use crate::ctypes::c_int;
+use crate::fs::opened_file::Fd;
+use crate::net::ShutdownHow;
+use crate::result::Result;
+use crate::{process::current_process, syscalls::SyscallHandler};
+
+impl<'a> SyscallHandler<'a> {
+    pub fn sys_shutdown(&mut self, fd: Fd, how: c_int) -> Result<isize> {
+        let opened_file = current_process().get_opened_file_by_fd(fd)?;
+        opened_file.shutdown(ShutdownHow::RdWr /* FIXME: */)?;
+        Ok(0)
+    }
+}


### PR DESCRIPTION
Since smoltcp seems not to support the `shutdown(2)` behavior, this PR implements the system call by closing the socket regardless of `how`.