### PR TITLE
Support freeing pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "buddy_system_allocator"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +124,12 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "funty"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "getrandom"
@@ -196,7 +214,9 @@ dependencies = [
 name = "kerla_utils"
 version = "0.0.1"
 dependencies = [
+ "bitvec",
  "crossbeam",
+ "log",
  "spin 0.9.2",
 ]
 
@@ -277,6 +297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "raw-cpuid"
 version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +348,12 @@ checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "unicode-xid"
@@ -388,6 +420,15 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wyz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x86"

--- a/libs/kerla_utils/Cargo.toml
+++ b/libs/kerla_utils/Cargo.toml
@@ -14,5 +14,7 @@ path = "lib.rs"
 no_std = []
 
 [dependencies]
+log = "0.4"
 spin = "0.9.2"
 crossbeam = { version = "0.8.1", default-features = false }
+bitvec = { version = "0.22", default-features = false }

--- a/libs/kerla_utils/bitmap_allocator.rs
+++ b/libs/kerla_utils/bitmap_allocator.rs
@@ -1,0 +1,71 @@
+use bitvec::prelude::*;
+
+use crate::alignment::align_up;
+
+const PAGE_SIZE: usize = 4096;
+
+pub struct BitMapAllocator {
+    bitmap: spin::Mutex<&'static mut BitSlice<Lsb0, u8>>,
+    base: usize,
+    end: usize,
+}
+
+impl BitMapAllocator {
+    /// # Safety
+    ///
+    /// The caller must ensure that the memory passed to this function is
+    /// aligned to a page boundary.
+    pub unsafe fn new(base: *mut u8, base_paddr: usize, len: usize) -> BitMapAllocator {
+        let num_pages = align_up(len, PAGE_SIZE) / PAGE_SIZE;
+        let bitmap_reserved_len = align_up(num_pages / 8, PAGE_SIZE);
+        let bitmap_actual_len = (num_pages / 8) - (bitmap_reserved_len / PAGE_SIZE);
+        let bitmap =
+            BitSlice::from_slice_mut(core::slice::from_raw_parts_mut(base, bitmap_actual_len))
+                .expect("you have too much memory");
+
+        debug_assert!(bitmap_reserved_len >= bitmap_actual_len);
+        bitmap.set_all(false);
+
+        BitMapAllocator {
+            bitmap: spin::Mutex::new(bitmap),
+            base: base_paddr + bitmap_reserved_len,
+            end: base_paddr + len - bitmap_reserved_len,
+        }
+    }
+
+    pub fn includes(&mut self, ptr: usize) -> bool {
+        self.base <= ptr && ptr < self.end
+    }
+
+    pub fn alloc_pages(&mut self, order: usize) -> Option<usize> {
+        let num_pages = 1 << order;
+        let mut bitmap = self.bitmap.lock();
+        let mut off = 0;
+        while let Some(first_zero) = bitmap[off..].first_zero() {
+            let start = off + first_zero;
+            let end = off + first_zero + num_pages;
+            if end > bitmap.len() {
+                break;
+            }
+
+            if bitmap[start..end].not_any() {
+                bitmap[start..end].set_all(true);
+                return Some(self.base + start * PAGE_SIZE);
+            }
+
+            off += first_zero + 1;
+        }
+
+        None
+    }
+
+    pub fn free_pages(&mut self, ptr: usize, order: usize) {
+        let num_pages = 1 << order;
+        let off = (ptr - self.base) / PAGE_SIZE;
+
+        let mut bitmap = self.bitmap.lock();
+
+        debug_assert!(bitmap[off..(off + num_pages)].all(), "double free");
+        bitmap[off..(off + num_pages)].set_all(false);
+    }
+}

--- a/libs/kerla_utils/bump_allocator.rs
+++ b/libs/kerla_utils/bump_allocator.rs
@@ -1,16 +1,26 @@
 const PAGE_SIZE: usize = 4096;
 
 pub struct BumpAllocator {
+    base: usize,
     current: usize,
     end: usize,
 }
 
 impl BumpAllocator {
-    pub fn new(_base: *mut u8, base_paddr: usize, len: usize) -> BumpAllocator {
+    /// # Safety
+    ///
+    /// The caller must ensure that the memory passed to this function is
+    /// aligned to a page boundary.
+    pub unsafe fn new(_base: *mut u8, base_paddr: usize, len: usize) -> BumpAllocator {
         BumpAllocator {
+            base: base_paddr,
             current: base_paddr,
             end: base_paddr + len,
         }
+    }
+
+    pub fn includes(&mut self, ptr: usize) -> bool {
+        self.base <= ptr && ptr < self.end
     }
 
     pub fn alloc_pages(&mut self, order: usize) -> Option<usize> {
@@ -22,5 +32,9 @@ impl BumpAllocator {
         let ptr = self.current;
         self.current += len;
         Some(ptr)
+    }
+
+    pub fn free_pages(&mut self, _ptr: usize, _order: usize) {
+        // Not supported.
     }
 }

--- a/libs/kerla_utils/lib.rs
+++ b/libs/kerla_utils/lib.rs
@@ -11,8 +11,12 @@ extern crate std;
 #[macro_use]
 extern crate alloc;
 
+#[macro_use]
+extern crate log;
+
 pub mod alignment;
 pub mod bitmap;
+pub mod bitmap_allocator;
 pub mod buddy_allocator;
 pub mod bump_allocator;
 pub mod byte_size;


### PR DESCRIPTION
Add `free_pages` and a new allocator supporting freeing pages `BitMapAllocator`.

This commit also introduces OwnedPages, which owns dynamically allocated
pages and will automatically frees the pages on drop.
