### PR TITLE
Re-disable interrupts after handling an interrupt

### DIFF
--- a/runtime/x64/idle.rs
+++ b/runtime/x64/idle.rs
@@ -2,7 +2,7 @@ use super::semihosting::{semihosting_halt, SemihostingExitStatus};
 
 pub fn idle() {
     unsafe {
-        asm!("sti; hlt");
+        asm!("sti; hlt; cli");
     }
 }
 


### PR DESCRIPTION
Currently, it seems a bug occurs if interrupts are enabled in the
kernel context.

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
