### PR TITLE
Implement /proc/metrics

### DIFF
--- a/kernel/fs/mod.rs
+++ b/kernel/fs/mod.rs
@@ -5,5 +5,6 @@ pub mod inode;
 pub mod mount;
 pub mod opened_file;
 pub mod path;
+pub mod procfs;
 pub mod stat;
 pub mod tmpfs;

--- a/kernel/fs/procfs/metrics.rs
+++ b/kernel/fs/procfs/metrics.rs
@@ -1,0 +1,106 @@
+use core::fmt;
+
+use kerla_runtime::page_allocator::read_allocator_stats;
+
+use crate::{
+    fs::{
+        inode::{FileLike, INodeNo},
+        opened_file::OpenOptions,
+        stat::{FileMode, Stat, S_IFCHR},
+    },
+    net::read_tcp_stats,
+    process::read_process_stats,
+    result::Result,
+    user_buffer::UserBufferMut,
+    user_buffer::{UserBufWriter, UserBuffer},
+};
+
+/// The `/proc/metrics` file. It returns the metrics of the kernel in Prometheus format.
+pub(super) struct MetricsFile {}
+
+impl MetricsFile {
+    pub fn new() -> MetricsFile {
+        MetricsFile {}
+    }
+}
+
+impl fmt::Debug for MetricsFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Metrics").finish()
+    }
+}
+
+impl FileLike for MetricsFile {
+    fn stat(&self) -> Result<Stat> {
+        Ok(Stat {
+            inode_no: INodeNo::new(2),
+            mode: FileMode::new(S_IFCHR | 0o666),
+            ..Stat::zeroed()
+        })
+    }
+
+    fn read(&self, offset: usize, buf: UserBufferMut<'_>, _options: &OpenOptions) -> Result<usize> {
+        use core::fmt::Write;
+
+        if offset > 0 {
+            // EOF. I guess there's a better way to do this.
+            return Ok(0);
+        }
+
+        let mut writer = UserBufWriter::from(buf);
+
+        // Process related metrics.
+        let process_metrics = read_process_stats();
+        let _ = write!(
+            writer,
+            concat!(
+                "# HELP: process_fork_total The total # of process forks.\n",
+                "# TYPE: process_fork_total counter\n",
+                "process_fork_total {fork_total}\n",
+            ),
+            fork_total = process_metrics.fork_total
+        );
+
+        // Allocator  metrics.
+        let allocator_metrics = read_allocator_stats();
+        let _ = write!(
+            writer,
+            concat!(
+                "# HELP: memory_pages_total The total # of pages can be allocated.\n",
+                "# TYPE: memory_pages_total gauge\n",
+                "memory_pages_total {num_free_pages}\n",
+                "# HELP: memory_pages_free The total # of pages can be allocated.\n",
+                "# TYPE: memory_pages_free gauge\n",
+                "memory_pages_free {num_total_pages}\n",
+            ),
+            num_free_pages = allocator_metrics.num_free_pages,
+            num_total_pages = allocator_metrics.num_total_pages
+        );
+
+        // TCP metrics.
+        let tcp_metrics = read_tcp_stats();
+        let _ = write!(
+            writer,
+            concat!(
+                "# HELP: passive_opens_total The total # of established passive TCP opens.\n",
+                "# TYPE: passive_opens_total counter\n",
+                "passive_opens_total {passive_opens_total}\n",
+                "# HELP: tcp_read_bytes_total The total bytes read from TCP socket buffers.\n",
+                "# TYPE: tcp_read_bytes_total counter\n",
+                "tcp_read_bytes_total {tcp_read_bytes_total}\n",
+                "# HELP: tcp_written_bytes_total The total bytes written into TCP socket buffers.\n",
+                "# TYPE: tcp_written_bytes_total counter\n",
+                "tcp_written_bytes_total {tcp_written_bytes_total}\n",
+            ),
+            passive_opens_total = tcp_metrics.passive_opens_total,
+            tcp_read_bytes_total = tcp_metrics.read_bytes_total,
+            tcp_written_bytes_total = tcp_metrics.written_bytes_total,
+        );
+
+        Ok(writer.written_len())
+    }
+
+    fn write(&self, _offset: usize, buf: UserBuffer<'_>, _options: &OpenOptions) -> Result<usize> {
+        Ok(buf.len())
+    }
+}

--- a/kernel/fs/procfs/metrics.rs
+++ b/kernel/fs/procfs/metrics.rs
@@ -47,41 +47,23 @@ impl FileLike for MetricsFile {
             return Ok(0);
         }
 
-        let mut writer = UserBufWriter::from(buf);
-
-        // Process related metrics.
         let process_metrics = read_process_stats();
+        let allocator_metrics = read_allocator_stats();
+        let tcp_metrics = read_tcp_stats();
+
+        let mut writer = UserBufWriter::from(buf);
         let _ = write!(
             writer,
             concat!(
                 "# HELP: process_fork_total The total # of process forks.\n",
                 "# TYPE: process_fork_total counter\n",
                 "process_fork_total {fork_total}\n",
-            ),
-            fork_total = process_metrics.fork_total
-        );
-
-        // Allocator  metrics.
-        let allocator_metrics = read_allocator_stats();
-        let _ = write!(
-            writer,
-            concat!(
                 "# HELP: memory_pages_total The total # of pages can be allocated.\n",
                 "# TYPE: memory_pages_total gauge\n",
                 "memory_pages_total {num_free_pages}\n",
                 "# HELP: memory_pages_free The total # of pages can be allocated.\n",
                 "# TYPE: memory_pages_free gauge\n",
                 "memory_pages_free {num_total_pages}\n",
-            ),
-            num_free_pages = allocator_metrics.num_free_pages,
-            num_total_pages = allocator_metrics.num_total_pages
-        );
-
-        // TCP metrics.
-        let tcp_metrics = read_tcp_stats();
-        let _ = write!(
-            writer,
-            concat!(
                 "# HELP: passive_opens_total The total # of established passive TCP opens.\n",
                 "# TYPE: passive_opens_total counter\n",
                 "passive_opens_total {passive_opens_total}\n",
@@ -92,6 +74,9 @@ impl FileLike for MetricsFile {
                 "# TYPE: tcp_written_bytes_total counter\n",
                 "tcp_written_bytes_total {tcp_written_bytes_total}\n",
             ),
+            fork_total = process_metrics.fork_total,
+            num_free_pages = allocator_metrics.num_free_pages,
+            num_total_pages = allocator_metrics.num_total_pages,
             passive_opens_total = tcp_metrics.passive_opens_total,
             tcp_read_bytes_total = tcp_metrics.read_bytes_total,
             tcp_written_bytes_total = tcp_metrics.written_bytes_total,

--- a/kernel/fs/procfs/mod.rs
+++ b/kernel/fs/procfs/mod.rs
@@ -1,0 +1,43 @@
+use crate::{
+    fs::{
+        file_system::FileSystem,
+        inode::{Directory, FileLike},
+    },
+    result::Result,
+};
+use alloc::sync::Arc;
+use kerla_utils::once::Once;
+
+use self::metrics::MetricsFile;
+
+use super::tmpfs::TmpFs;
+
+mod metrics;
+
+pub static PROC_FS: Once<Arc<ProcFs>> = Once::new();
+static METRICS_FILE: Once<Arc<dyn FileLike>> = Once::new();
+
+pub struct ProcFs(TmpFs);
+
+impl ProcFs {
+    pub fn new() -> ProcFs {
+        let tmpfs = TmpFs::new();
+        let root_dir = tmpfs.root_tmpfs_dir();
+
+        METRICS_FILE.init(|| Arc::new(MetricsFile::new()) as Arc<dyn FileLike>);
+
+        root_dir.add_file("metrics", METRICS_FILE.clone());
+
+        ProcFs(tmpfs)
+    }
+}
+
+impl FileSystem for ProcFs {
+    fn root_dir(&self) -> Result<Arc<dyn Directory>> {
+        self.0.root_dir()
+    }
+}
+
+pub fn init() {
+    PROC_FS.init(|| Arc::new(ProcFs::new()));
+}

--- a/kernel/net/tcp_socket.rs
+++ b/kernel/net/tcp_socket.rs
@@ -28,6 +28,7 @@ static PASSIVE_OPENS_TOTAL: AtomicUsize = AtomicUsize::new(0);
 static WRITTEN_BYTES_TOTAL: AtomicUsize = AtomicUsize::new(0);
 static READ_BYTES_TOTAL: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Debug)]
 pub struct Stats {
     pub passive_opens_total: usize,
     pub written_bytes_total: usize,

--- a/kernel/process/mod.rs
+++ b/kernel/process/mod.rs
@@ -16,7 +16,7 @@ pub mod signal;
 mod switch;
 mod wait_queue;
 
-pub use process::{gc_exited_processes, PId, Process, ProcessState};
+pub use process::{gc_exited_processes, read_process_stats, PId, Process, ProcessState};
 pub use switch::switch;
 pub use wait_queue::WaitQueue;
 

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -46,6 +46,7 @@ pub(super) static EXITED_PROCESSES: SpinLock<Vec<Arc<Process>>> = SpinLock::new(
 
 static FORK_TOTAL: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Debug)]
 pub struct Stats {
     pub fork_total: usize,
 }

--- a/kernel/user_buffer.rs
+++ b/kernel/user_buffer.rs
@@ -296,6 +296,14 @@ impl<'a> From<UserBufferMut<'a>> for UserBufWriter<'a> {
     }
 }
 
+impl<'a> core::fmt::Write for UserBufWriter<'a> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write_bytes(s.as_bytes())
+            .map_err(|_| core::fmt::Error)?;
+        Ok(())
+    }
+}
+
 /// A user-provided NULL-terminated string.
 ///
 /// It's a copy of the string (not a reference) since the user can modify the

--- a/libs/kerla_utils/bitmap_allocator.rs
+++ b/libs/kerla_utils/bitmap_allocator.rs
@@ -33,6 +33,10 @@ impl BitMapAllocator {
         }
     }
 
+    pub fn num_total_pages(&self) -> usize {
+        (self.end - self.base) / PAGE_SIZE
+    }
+
     pub fn includes(&mut self, ptr: usize) -> bool {
         self.base <= ptr && ptr < self.end
     }

--- a/runtime/page_allocator.rs
+++ b/runtime/page_allocator.rs
@@ -1,4 +1,5 @@
 use core::ops::Deref;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{address::PAddr, arch::PAGE_SIZE, bootinfo::RamArea, spinlock::SpinLock};
 use arrayvec::ArrayVec;
@@ -15,6 +16,8 @@ use kerla_utils::bitmap_allocator::BitMapAllocator as Allocator;
 // use kerla_utils::bump_allocator::BumpAllocator as Allocator;
 
 static ZONES: SpinLock<ArrayVec<Allocator, 8>> = SpinLock::new(ArrayVec::new_const());
+static NUM_FREE_PAGES: AtomicUsize = AtomicUsize::new(0);
+static NUM_TOTAL_PAGES: AtomicUsize = AtomicUsize::new(0);
 
 fn num_pages_to_order(num_pages: usize) -> usize {
     // TODO: Use log2 instead
@@ -27,6 +30,18 @@ fn num_pages_to_order(num_pages: usize) -> usize {
     }
 
     unreachable!();
+}
+
+pub struct Stats {
+    pub num_free_pages: usize,
+    pub num_total_pages: usize,
+}
+
+pub fn read_allocator_stats() -> Stats {
+    Stats {
+        num_free_pages: NUM_FREE_PAGES.load(Ordering::SeqCst),
+        num_total_pages: NUM_TOTAL_PAGES.load(Ordering::SeqCst),
+    }
 }
 
 bitflags! {
@@ -70,6 +85,7 @@ impl Drop for OwnedPages {
     }
 }
 
+// TODO: Use alloc_page
 pub fn alloc_pages(num_pages: usize, flags: AllocPageFlags) -> Result<PAddr, PageAllocError> {
     let order = num_pages_to_order(num_pages);
     let mut zones = ZONES.lock();
@@ -83,6 +99,7 @@ pub fn alloc_pages(num_pages: usize, flags: AllocPageFlags) -> Result<PAddr, Pag
                 }
             }
 
+            NUM_FREE_PAGES.fetch_sub(num_pages, Ordering::SeqCst);
             return Ok(paddr);
         }
     }
@@ -106,6 +123,7 @@ pub fn alloc_pages_owned(
                 }
             }
 
+            NUM_FREE_PAGES.fetch_sub(num_pages, Ordering::SeqCst);
             return Ok(OwnedPages::new(paddr, num_pages));
         }
     }
@@ -130,6 +148,7 @@ pub fn free_pages(paddr: PAddr, num_pages: usize) {
     for zone in zones.iter_mut() {
         if zone.includes(paddr.value()) {
             zone.free_pages(paddr.value(), order);
+            NUM_FREE_PAGES.fetch_add(num_pages, Ordering::SeqCst);
             return;
         }
     }
@@ -147,6 +166,8 @@ pub fn init(areas: &[RamArea]) {
         debug_assert!(is_aligned(area.base.value(), PAGE_SIZE));
         let allocator =
             unsafe { Allocator::new(area.base.as_mut_ptr(), area.base.value(), area.len) };
+        NUM_FREE_PAGES.fetch_add(allocator.num_total_pages(), Ordering::SeqCst);
+        NUM_TOTAL_PAGES.fetch_add(allocator.num_total_pages(), Ordering::SeqCst);
         zones.push(allocator);
     }
 }

--- a/runtime/page_allocator.rs
+++ b/runtime/page_allocator.rs
@@ -32,6 +32,7 @@ fn num_pages_to_order(num_pages: usize) -> usize {
     unreachable!();
 }
 
+#[derive(Debug)]
 pub struct Stats {
     pub num_free_pages: usize,
     pub num_total_pages: usize,


### PR DESCRIPTION
/proc/metrics is a Kerla-specific feature which exposes some metrics in
the kernel, in the Prometheus format.

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
