### PR TITLE
net: Fix for dhcp=off

### DIFF
--- a/libs/virtio/transports/virtio_pci_legacy.rs
+++ b/libs/virtio/transports/virtio_pci_legacy.rs
@@ -62,7 +62,6 @@ impl VirtioTransport for VirtioLegacyPci {
     }
 
     fn read_device_status(&self) -> u8 {
-        info!("read dev");
         self.port_base.read8(REG_DEVICE_STATUS)
     }
 


### PR DESCRIPTION
DHCP_CLIENT is not initialized when dhcp=off.

<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
