### PR TITLE
x64: Fill an XSAVE area with zeroes

### DIFF
--- a/kernel/arch/x64/process.rs
+++ b/kernel/arch/x64/process.rs
@@ -82,7 +82,7 @@ impl Process {
             .expect("failed to allocate kernel stack")
             .as_vaddr();
         // TODO: Check the size of XSAVE area.
-        let xsave_area = alloc_pages(1, AllocPageFlags::KERNEL)
+        let xsave_area = alloc_pages(1, AllocPageFlags::KERNEL | AllocPageFlags::ZEROED)
             .expect("failed to allocate xsave area")
             .as_vaddr();
 
@@ -137,7 +137,7 @@ impl Process {
 
     pub fn fork(&self, frame: &PtRegs) -> Result<Process> {
         // TODO: Check the size of XSAVE area.
-        let xsave_area = alloc_pages(1, AllocPageFlags::KERNEL)
+        let xsave_area = alloc_pages(1, AllocPageFlags::KERNEL | AllocPageFlags::ZEROED)
             .expect("failed to allocate xsave area")
             .as_vaddr();
 


### PR DESCRIPTION
<!--

Contributor Guidelines

First of all, thank you for submitting a pull request! To improve the quality please
follow the following instructions.

a) The PR title will be the commit message. Describe your changes briefly and
   use the present tense, without a trailing full stop:

   BAD:  "Fixed a bug."
   GOOD: "virtio-net: Fix an off-by-one error"

b) Prefer using `#123` over `ISSUE-123` to mention an issue or a PR.
c) Address compiler warnings (or add `#[allow(...)]`) before submitting the PR.
d) Add "Closes #123" or "Fixes #123" in the PR description to automatically close the corresponding issue.

Please feel free to remove this comment.

-->
