### PR TITLE
[Resolves #142] Add lifetimes to VAddr & PAddr

### DIFF
--- a/runtime/bootinfo.rs
+++ b/runtime/bootinfo.rs
@@ -3,12 +3,12 @@ use arrayvec::{ArrayString, ArrayVec};
 use crate::address::PAddr;
 
 pub struct RamArea {
-    pub base: PAddr,
+    pub base: PAddr<'static>,
     pub len: usize,
 }
 
 pub struct VirtioMmioDevice {
-    pub mmio_base: PAddr,
+    pub mmio_base: PAddr<'static>,
     pub irq: u8,
 }
 

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![feature(asm)]
 #![feature(global_asm)]
+#![feature(in_band_lifetimes)]
 
 extern crate alloc;
 

--- a/runtime/x64/apic.rs
+++ b/runtime/x64/apic.rs
@@ -16,11 +16,11 @@ enum LocalApicReg {
     SpuriousInterrupt = 0xf0,
 }
 
-struct LocalApic {
-    base: PAddr,
+struct LocalApic<'memory> {
+    base: PAddr<'memory>,
 }
 
-impl LocalApic {
+impl LocalApic<'_> {
     pub const fn new(base: PAddr) -> LocalApic {
         LocalApic { base }
     }

--- a/runtime/x64/ioapic.rs
+++ b/runtime/x64/ioapic.rs
@@ -14,11 +14,11 @@ enum IoApicReg {
     RedirectTableBase = 0x10,
 }
 
-struct IoApic {
-    base: PAddr,
+struct IoApic<'memory> {
+    base: PAddr<'memory>,
 }
 
-impl IoApic {
+impl IoApic<'_> {
     pub const fn new(base: PAddr) -> IoApic {
         IoApic { base }
     }

--- a/runtime/x64/paging.rs
+++ b/runtime/x64/paging.rs
@@ -29,7 +29,7 @@ bitflags! {
     }
 }
 
-fn entry_paddr(entry: PageTableEntry) -> PAddr {
+fn entry_paddr(entry: PageTableEntry) -> PAddr<'static> {
     PAddr::new((entry & 0x7ffffffffffff000) as usize)
 }
 
@@ -127,7 +127,7 @@ fn duplicate_table(original_table_paddr: PAddr, level: usize) -> Result<PAddr, P
     Ok(new_table_paddr)
 }
 
-fn allocate_pml4() -> Result<PAddr, PageAllocError> {
+fn allocate_pml4() -> Result<PAddr<'static>, PageAllocError> {
     extern "C" {
         static __kernel_pml4: u8;
     }
@@ -154,7 +154,7 @@ fn allocate_pml4() -> Result<PAddr, PageAllocError> {
 }
 
 pub struct PageTable {
-    pml4: PAddr,
+    pml4: PAddr<'static>,
 }
 
 impl PageTable {

--- a/runtime/x64/vga.rs
+++ b/runtime/x64/vga.rs
@@ -35,7 +35,7 @@ const BANNER: &str =
     " Kerla       /dev/console is connected to the serial port (no keyboard support) ";
 
 struct Console {
-    base: VAddr,
+    base: VAddr<'static>,
     x: usize,
     y: usize,
     fg: VgaColor,


### PR DESCRIPTION
## Description

An unfinished attempt to add lifetimes to `VAddr` & `PAddr` (as per #142).

@nuta I stuck with:
```
error[E0308]: mismatched types
   --> runtime/backtrace.rs:113:56
    |
113 |         Backtrace::current_frame().traverse(|_, vaddr: VAddr<'memory>| {
    |                                                        ^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected struct `address::VAddr<'_>`
               found struct `address::VAddr<'memory>`
note: the anonymous lifetime #1 defined here...
   --> runtime/backtrace.rs:113:45
    |
113 |           Backtrace::current_frame().traverse(|_, vaddr: VAddr<'memory>| {
    |  _____________________________________________^
114 | |             if let Some(symbol) = resolve_symbol(vaddr) {
115 | |                 let _ = trace.try_push(CapturedBacktraceFrame::<'memory> {
116 | |                     vaddr,
...   |
120 | |             }
121 | |         });
    | |_________^
note: ...does not necessarily outlive the lifetime `'memory` as defined here
   --> runtime/backtrace.rs:111:43
    |
111 |     pub fn capture() -> CapturedBacktrace<'memory> {
    |                                           ^^^^^^^
```
I'm not the expert of lifetimes, but I read this a problem with the lifetime of the closure as argument of `traverse()`. Any suggestions welcome.

## Pre-Submission Checklist

When you submit a PR, please make sure your PR satisfies the following checklist:

- [X] I assert this contribution was authored by me.
- [X] I license this contribution under the license of this project.
- [X] The PR title describes your changes briefly and uses the present tense, without a trailing full stop.
- [X] The PR description describes the reason why we need the change.
- [X] This is an isolated change. No multiple changes and no unrelated changes are included.
- [ ] Fixed all `cargo clippy` warnings.
- [ ] Applied `rustfmt`.
