### PR TITLE
marked semihosting_halt function unsafe

### DIFF
--- a/kernel/test_runner.rs
+++ b/kernel/test_runner.rs
@@ -31,7 +31,7 @@ pub fn run_tests(tests: &[&dyn Testable]) {
 }
 
 pub fn end_tests() -> ! {
-    semihosting_halt(SemihostingExitStatus::Success);
+    unsafe { semihosting_halt(SemihostingExitStatus::Success) };
 
     #[allow(clippy::empty_loop)]
     loop {}
@@ -48,6 +48,6 @@ fn panic(info: &PanicInfo) -> ! {
 
     PANICKED.store(true, Ordering::SeqCst);
     print!("\x1b[1;91mfail\npanic: {}\x1b[0m", info);
-    semihosting_halt(SemihostingExitStatus::Failure);
+    unsafe { semihosting_halt(SemihostingExitStatus::Failure) };
     loop {}
 }

--- a/runtime/x64/idle.rs
+++ b/runtime/x64/idle.rs
@@ -10,7 +10,7 @@ pub fn idle() {
 
 #[cfg_attr(test, allow(unused))]
 pub fn halt() -> ! {
-    semihosting_halt(SemihostingExitStatus::Success);
+    unsafe { semihosting_halt(SemihostingExitStatus::Success) };
 
     loop {
         unsafe {

--- a/runtime/x64/semihosting.rs
+++ b/runtime/x64/semihosting.rs
@@ -7,7 +7,7 @@ pub enum SemihostingExitStatus {
     Failure = 0x11,
 }
 
-pub fn semihosting_halt(status: SemihostingExitStatus) {
+pub unsafe fn semihosting_halt(status: SemihostingExitStatus) {
     unsafe {
         outw(0x501, status as u16);
     }


### PR DESCRIPTION
## Description

Please describe the PR here.

## Pre-Submission Checklist

When you submit a PR, please make sure your PR satisfies the following checklist:

- [ ] I assert this contribution was authored by me.
- [ ] I license this contribution under the license of this project.
- [ ] The PR title describes your changes briefly and uses the present tense, without a trailing full stop.
- [ ] The PR description describes the reason why we need the change.
- [ ] This is an isolated change. No multiple changes and no unrelated changes are included.
- [ ] Fixed all `cargo clippy` warnings.
- [ ] Applied `rustfmt`.
https://github.com/nuta/kerla/blob/e1ddf73614a7bc5a400e9739b4f3a20af2ed045e/runtime/x64/semihosting.rs#L10-L14
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.