### PR TITLE
Get CI testing working again and prevent future bit-rot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           cargo --version
 
       - name: Install cargo crates
-        run: cargo install cargo-binutils rustfilt
+        run: cargo install cargo-binutils@0.3.6 rustfilt@0.2.1
 
       - name: make check
         run: make check

--- a/kernel/arch/x64/process.rs
+++ b/kernel/arch/x64/process.rs
@@ -17,6 +17,9 @@ pub struct Process {
     rsp: UnsafeCell<u64>,
     pub(super) fsbase: AtomicCell<u64>,
     pub(super) xsave_area: Option<OwnedPages>,
+    // This appears dead, but really we're keeping the pages referenced from the
+    // rsp from being dropped until the Process is dropped.
+    #[allow(dead_code)]
     kernel_stack: OwnedPages,
     // FIXME: Do we really need these stacks?
     interrupt_stack: OwnedPages,

--- a/kernel/arch/x64/process.rs
+++ b/kernel/arch/x64/process.rs
@@ -13,7 +13,6 @@ use kerla_runtime::{
 };
 use x86::current::segmentation::wrfsbase;
 
-#[repr(C, packed)]
 pub struct Process {
     rsp: UnsafeCell<u64>,
     pub(super) fsbase: AtomicCell<u64>,

--- a/kernel/arch/x64/process.rs
+++ b/kernel/arch/x64/process.rs
@@ -45,17 +45,17 @@ impl Process {
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
         )
-        .expect("failed to allocate kernel stack");
+        .expect("failed to allocate interrupt stack");
         let syscall_stack = alloc_pages_owned(
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
         )
-        .expect("failed to allocate kernel stack");
+        .expect("failed to allocate syscall stack");
         let kernel_stack = alloc_pages_owned(
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
         )
-        .expect("failed to allocat kernel stack");
+        .expect("failed to allocate kernel stack");
 
         let rsp = unsafe {
             let mut rsp: *mut u64 = sp.as_mut_ptr();
@@ -91,7 +91,7 @@ impl Process {
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
         )
-        .expect("failed to allocat kernel stack");
+        .expect("failed to allocate kernel stack");
         let interrupt_stack = alloc_pages_owned(
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
@@ -173,7 +173,7 @@ impl Process {
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
         )
-        .expect("failed to allocat kernel stack");
+        .expect("failed to allocate kernel stack");
         let rsp = unsafe {
             let kernel_sp = kernel_stack.as_vaddr().add(KERNEL_STACK_SIZE);
             let mut rsp: *mut u64 = kernel_sp.as_mut_ptr();
@@ -212,12 +212,12 @@ impl Process {
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
         )
-        .expect("failed allocate kernel stack");
+        .expect("failed allocate interrupt stack");
         let syscall_stack = alloc_pages_owned(
             KERNEL_STACK_SIZE / PAGE_SIZE,
             AllocPageFlags::KERNEL | AllocPageFlags::DIRTY_OK,
         )
-        .expect("failed allocate kernel stack");
+        .expect("failed allocate syscall stack");
 
         Ok(Process {
             rsp: UnsafeCell::new(rsp as u64),

--- a/kernel/fs/mount.rs
+++ b/kernel/fs/mount.rs
@@ -96,7 +96,8 @@ impl RootFs {
 
     fn lookup_mount_point(&self, dir: &Arc<dyn Directory>) -> Result<Option<&MountPoint>> {
         let stat = dir.stat()?;
-        Ok(self.mount_points.get(&stat.inode_no))
+        let inode_no = stat.inode_no; // Move out of unaligned
+        Ok(self.mount_points.get(&inode_no))
     }
 
     /// Resolves a path into `PathComponent`. If `follow_symlink` is `true`,

--- a/kernel/fs/opened_file.rs
+++ b/kernel/fs/opened_file.rs
@@ -1,3 +1,6 @@
+// Allow the bad bit mask of O_RDONLY
+#![allow(clippy::bad_bit_mask)]
+
 use super::{
     inode::{DirEntry, Directory, FileLike, INode},
     path::PathBuf,

--- a/kernel/fs/path.rs
+++ b/kernel/fs/path.rs
@@ -175,7 +175,7 @@ impl AsRef<Path> for PathBuf {
     }
 }
 
-impl<'a> From<&Path> for PathBuf {
+impl From<&Path> for PathBuf {
     fn from(path: &Path) -> PathBuf {
         PathBuf {
             path: path.path.to_owned(),

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -6,8 +6,6 @@
 #![feature(array_methods)]
 #![test_runner(crate::test_runner::run_tests)]
 #![reexport_test_harness_main = "test_main"]
-// FIXME:
-#![allow(unaligned_references)]
 #![feature(trait_alias)]
 
 #[macro_use]

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -2,7 +2,6 @@
 #![no_main]
 #![feature(custom_test_frameworks)]
 #![feature(alloc_error_handler)]
-#![feature(const_btree_new)]
 #![feature(array_methods)]
 #![test_runner(crate::test_runner::run_tests)]
 #![reexport_test_harness_main = "test_main"]

--- a/kernel/net/mod.rs
+++ b/kernel/net/mod.rs
@@ -58,11 +58,11 @@ impl From<MonotonicClock> for Instant {
     }
 }
 
-pub(self) static SOCKETS: Once<SpinLock<SocketSet>> = Once::new();
+static SOCKETS: Once<SpinLock<SocketSet>> = Once::new();
 static INTERFACE: Once<SpinLock<EthernetInterface<OurDevice>>> = Once::new();
 static DHCP_CLIENT: Once<SpinLock<Dhcpv4Client>> = Once::new();
 static DHCP_ENABLED: Once<bool> = Once::new();
-pub(self) static SOCKET_WAIT_QUEUE: Once<WaitQueue> = Once::new();
+static SOCKET_WAIT_QUEUE: Once<WaitQueue> = Once::new();
 
 pub fn process_packets() {
     let mut sockets = SOCKETS.lock();

--- a/kernel/net/socket.rs
+++ b/kernel/net/socket.rs
@@ -8,14 +8,13 @@ use smoltcp::wire::{IpAddress, IpEndpoint, Ipv4Address};
 bitflags! {
     pub struct RecvFromFlags: i32 {
         // TODO:
-        const _NOT_IMPLEMENTED = 0;
+        const _NOT_IMPLEMENTED = 0x1;
     }
 }
 
 bitflags! {
     pub struct SendToFlags: i32 {
-        // TODO:
-        const _NOT_IMPLEMENTED = 0;
+        // TODO: remaining flags
         const MSG_NOSIGNAL = 0x4000;
     }
 }

--- a/kernel/net/tcp_socket.rs
+++ b/kernel/net/tcp_socket.rs
@@ -112,7 +112,7 @@ impl FileLike for TcpSocket {
         SOCKET_WAIT_QUEUE.sleep_signalable_until(|| {
             let mut sockets = SOCKETS.lock();
             let mut backlogs = self.backlogs.lock();
-            match get_ready_backlog_index(&mut *sockets, &*backlogs) {
+            match get_ready_backlog_index(&mut sockets, &backlogs) {
                 Some(index) => {
                     // Pop the client socket and add a new socket into the backlog.
                     let socket = backlogs.remove(index);
@@ -313,7 +313,7 @@ impl FileLike for TcpSocket {
     fn poll(&self) -> Result<PollStatus> {
         let mut status = PollStatus::empty();
         let mut sockets = SOCKETS.lock();
-        if get_ready_backlog_index(&mut *sockets, &*self.backlogs.lock()).is_some() {
+        if get_ready_backlog_index(&mut sockets, &self.backlogs.lock()).is_some() {
             status |= PollStatus::POLLIN;
         }
 

--- a/kernel/process/process.rs
+++ b/kernel/process/process.rs
@@ -36,7 +36,7 @@ use kerla_runtime::{
     page_allocator::{alloc_pages, AllocPageFlags},
     spinlock::{SpinLock, SpinLockGuard},
 };
-use kerla_utils::{alignment::align_up};
+use kerla_utils::alignment::align_up;
 
 type ProcessTable = BTreeMap<PId, Arc<Process>>;
 

--- a/kernel/process/signal.rs
+++ b/kernel/process/signal.rs
@@ -1,6 +1,6 @@
 use crate::{ctypes::c_int, prelude::*};
-use kerla_runtime::address::UserVAddr;
 use bitvec::prelude::*;
+use kerla_runtime::address::UserVAddr;
 
 pub type Signal = c_int;
 #[allow(unused)]
@@ -160,7 +160,7 @@ impl SignalDelivery {
 }
 
 //pub type SigSet = BitMap<128 /* 1024 / 8 */>;
-pub type SigSet = BitArray<[u8; 1024 / 8 /* quark no_std? */], LocalBits>;
+pub type SigSet = BitArray<[u8; 1024 / 8], LocalBits>;
 pub enum SignalMask {
     Block,
     Unblock,

--- a/kernel/syscalls/linkat.rs
+++ b/kernel/syscalls/linkat.rs
@@ -18,13 +18,13 @@ impl<'a> SyscallHandler<'a> {
         let root_fs = current.root_fs().lock();
         let opened_files = current.opened_files().lock();
         let src = root_fs.lookup_path_at(
-            &*opened_files,
+            &opened_files,
             &src_dir,
             src_path,
             flags.contains(AtFlags::AT_SYMLINK_FOLLOW),
         )?;
         let (parent_dir, dst_name) =
-            root_fs.lookup_parent_path_at(&*opened_files, &dst_dir, dst_path, true)?;
+            root_fs.lookup_parent_path_at(&opened_files, &dst_dir, dst_path, true)?;
         parent_dir.inode.as_dir()?.link(dst_name, &src.inode)?;
         Ok(0)
     }

--- a/kernel/syscalls/mod.rs
+++ b/kernel/syscalls/mod.rs
@@ -16,64 +16,64 @@ use crate::{
 use bitflags::bitflags;
 use kerla_runtime::{address::UserVAddr, arch::PtRegs};
 
-pub(self) mod accept;
-pub(self) mod arch_prctl;
-pub(self) mod bind;
-pub(self) mod brk;
-pub(self) mod chdir;
-pub(self) mod chmod;
-pub(self) mod clock_gettime;
-pub(self) mod close;
-pub(self) mod connect;
-pub(self) mod dup2;
-pub(self) mod execve;
-pub(self) mod exit;
-pub(self) mod exit_group;
-pub(self) mod fcntl;
-pub(self) mod fork;
-pub(self) mod fstat;
-pub(self) mod fsync;
-pub(self) mod getcwd;
-pub(self) mod getdents64;
-pub(self) mod getpeername;
-pub(self) mod getpgid;
-pub(self) mod getpid;
-pub(self) mod getppid;
-pub(self) mod getrandom;
-pub(self) mod getsockname;
-pub(self) mod getsockopt;
-pub(self) mod gettid;
-pub(self) mod ioctl;
-pub(self) mod kill;
-pub(self) mod link;
-pub(self) mod linkat;
-pub(self) mod listen;
-pub(self) mod lstat;
-pub(self) mod mkdir;
-pub(self) mod mmap;
-pub(self) mod open;
-pub(self) mod pipe;
-pub(self) mod poll;
-pub(self) mod read;
-pub(self) mod readlink;
-pub(self) mod reboot;
-pub(self) mod recvfrom;
-pub(self) mod rt_sigaction;
-pub(self) mod rt_sigprocmask;
-pub(self) mod rt_sigreturn;
-pub(self) mod select;
-pub(self) mod sendto;
-pub(self) mod set_tid_address;
-pub(self) mod setpgid;
-pub(self) mod shutdown;
-pub(self) mod socket;
-pub(self) mod stat;
-pub(self) mod syslog;
-pub(self) mod uname;
-pub(self) mod utimes;
-pub(self) mod wait4;
-pub(self) mod write;
-pub(self) mod writev;
+mod accept;
+mod arch_prctl;
+mod bind;
+mod brk;
+mod chdir;
+mod chmod;
+mod clock_gettime;
+mod close;
+mod connect;
+mod dup2;
+mod execve;
+mod exit;
+mod exit_group;
+mod fcntl;
+mod fork;
+mod fstat;
+mod fsync;
+mod getcwd;
+mod getdents64;
+mod getpeername;
+mod getpgid;
+mod getpid;
+mod getppid;
+mod getrandom;
+mod getsockname;
+mod getsockopt;
+mod gettid;
+mod ioctl;
+mod kill;
+mod link;
+mod linkat;
+mod listen;
+mod lstat;
+mod mkdir;
+mod mmap;
+mod open;
+mod pipe;
+mod poll;
+mod read;
+mod readlink;
+mod reboot;
+mod recvfrom;
+mod rt_sigaction;
+mod rt_sigprocmask;
+mod rt_sigreturn;
+mod select;
+mod sendto;
+mod set_tid_address;
+mod setpgid;
+mod shutdown;
+mod socket;
+mod stat;
+mod syslog;
+mod uname;
+mod utimes;
+mod wait4;
+mod write;
+mod writev;
 
 pub enum CwdOrFd {
     /// `AT_FDCWD`
@@ -96,11 +96,11 @@ bitflags! {
     }
 }
 
-pub(self) const MAX_READ_WRITE_LEN: usize = core::isize::MAX as usize;
-pub(self) const IOV_MAX: usize = 1024;
+const MAX_READ_WRITE_LEN: usize = core::isize::MAX as usize;
+const IOV_MAX: usize = 1024;
 
 #[repr(C)]
-pub(self) struct IoVec {
+struct IoVec {
     base: UserVAddr,
     len: usize,
 }

--- a/kernel/syscalls/mod.rs
+++ b/kernel/syscalls/mod.rs
@@ -269,9 +269,7 @@ impl<'a> SyscallHandler<'a> {
                 &resolve_path(a4)?,
                 bitflags_from_user!(AtFlags, a5 as c_int)?,
             ),
-            SYS_READLINK => {
-                self.sys_readlink(&resolve_path(a1)?, UserVAddr::new_nonnull(a2)?, a3 as usize)
-            }
+            SYS_READLINK => self.sys_readlink(&resolve_path(a1)?, UserVAddr::new_nonnull(a2)?, a3),
             SYS_CHMOD => self.sys_chmod(&resolve_path(a1)?, FileMode::new(a2 as u32)),
             SYS_CHOWN => Ok(0), // TODO:
             SYS_FSYNC => self.sys_fsync(Fd::new(a1 as i32)),
@@ -325,11 +323,9 @@ impl<'a> SyscallHandler<'a> {
             SYS_EXIT => self.sys_exit(a1 as i32),
             SYS_EXIT_GROUP => self.sys_exit_group(a1 as i32),
             SYS_SOCKET => self.sys_socket(a1 as i32, a2 as i32, a3 as i32),
-            SYS_BIND => self.sys_bind(Fd::new(a1 as i32), UserVAddr::new_nonnull(a2)?, a3 as usize),
+            SYS_BIND => self.sys_bind(Fd::new(a1 as i32), UserVAddr::new_nonnull(a2)?, a3),
             SYS_SHUTDOWN => self.sys_shutdown(Fd::new(a1 as i32), a2 as i32),
-            SYS_CONNECT => {
-                self.sys_connect(Fd::new(a1 as i32), UserVAddr::new_nonnull(a2)?, a3 as usize)
-            }
+            SYS_CONNECT => self.sys_connect(Fd::new(a1 as i32), UserVAddr::new_nonnull(a2)?, a3),
             SYS_LISTEN => self.sys_listen(Fd::new(a1 as i32), a2 as c_int),
             SYS_GETSOCKNAME => self.sys_getsockname(
                 Fd::new(a1 as i32),
@@ -354,7 +350,7 @@ impl<'a> SyscallHandler<'a> {
             SYS_SENDTO => self.sys_sendto(
                 Fd::new(a1 as i32),
                 UserVAddr::new_nonnull(a2)?,
-                a3 as usize,
+                a3,
                 bitflags_from_user!(SendToFlags, a4 as i32)?,
                 UserVAddr::new(a5),
                 a6,
@@ -362,7 +358,7 @@ impl<'a> SyscallHandler<'a> {
             SYS_RECVFROM => self.sys_recvfrom(
                 Fd::new(a1 as i32),
                 UserVAddr::new_nonnull(a2)?,
-                a3 as usize,
+                a3,
                 bitflags_from_user!(RecvFromFlags, a4 as i32)?,
                 UserVAddr::new(a5),
                 UserVAddr::new(a6),

--- a/kernel/syscalls/open.rs
+++ b/kernel/syscalls/open.rs
@@ -44,7 +44,7 @@ impl<'a> SyscallHandler<'a> {
         let root_fs = current.root_fs().lock();
         let mut opened_files = current.opened_files().lock();
 
-        let path_comp = root_fs.lookup_path_at(&*opened_files, &CwdOrFd::AtCwd, path, true)?;
+        let path_comp = root_fs.lookup_path_at(&opened_files, &CwdOrFd::AtCwd, path, true)?;
         if flags.contains(OpenFlags::O_DIRECTORY) && !path_comp.inode.is_dir() {
             return Err(Error::new(Errno::ENOTDIR));
         }

--- a/kernel/syscalls/readlink.rs
+++ b/kernel/syscalls/readlink.rs
@@ -29,7 +29,7 @@ impl<'a> SyscallHandler<'a> {
                 .readlink()?
         };
 
-        if (buf_size as usize) < resolved_path.as_str().as_bytes().len() {
+        if buf_size < resolved_path.as_str().as_bytes().len() {
             return Err(Errno::ERANGE.into());
         }
 

--- a/libs/kerla_utils/buddy_allocator.rs
+++ b/libs/kerla_utils/buddy_allocator.rs
@@ -206,9 +206,8 @@ impl BuddyAllocator {
 
     fn refill_order(&mut self, order: usize) {
         // Look for the lowest order containing at least one free entry.
-        let available_order = ((order + 1)..BUDDY_ORDER_MAX)
-            .into_iter()
-            .find(|order| !self.free_lists[*order].is_empty());
+        let available_order =
+            ((order + 1)..BUDDY_ORDER_MAX).find(|order| !self.free_lists[*order].is_empty());
 
         if let Some(available_order) = available_order {
             for order in ((order + 1)..=available_order).rev() {

--- a/libs/kerla_utils/id_table.rs
+++ b/libs/kerla_utils/id_table.rs
@@ -1,5 +1,5 @@
-use core::mem::size_of;
 use bitvec::prelude::*;
+use core::mem::size_of;
 
 pub struct IdTable<const BIT_LENGTH: usize>(BitArray<[usize; BIT_LENGTH], LocalBits>); // const expr arithmetic unstable
 

--- a/libs/kerla_utils/lib.rs
+++ b/libs/kerla_utils/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(feature = "no_std", no_std)]
-#![feature(slice_internals)]
 #![feature(const_maybe_uninit_assume_init)]
 #![allow(unused)]
 

--- a/libs/virtio/device.rs
+++ b/libs/virtio/device.rs
@@ -157,10 +157,8 @@ impl VirtQueue {
                     num_freed += 1;
 
                     if (desc.flags & VIRTQ_DESC_F_NEXT) == 0 {
-                        #[allow(unaligned_references)]
-                        {
-                            debug_assert_eq!(desc.next, 0);
-                        }
+                        let next = desc.next;
+                        debug_assert_eq!(next, 0);
                         desc.next = prev_head;
                         break;
                     }

--- a/libs/virtio/transports/virtio_mmio.rs
+++ b/libs/virtio/transports/virtio_mmio.rs
@@ -25,7 +25,7 @@ impl VirtioTransport for VirtioMmio {
         unsafe {
             self.mmio_base
                 .add((0x100 + offset) as usize)
-                .read_volatile::<u8>() as u8
+                .read_volatile::<u8>()
         }
     }
 

--- a/runtime/page_allocator.rs
+++ b/runtime/page_allocator.rs
@@ -50,11 +50,11 @@ bitflags! {
         // TODO: Currently both of them are unused in the allocator.
 
         /// Allocate pages for the kernel purpose.
-        const KERNEL = 0;
+        const KERNEL = 1 << 0;
         /// Allocate pages for the user.
-        const USER = 0;
+        const USER = 1 << 1;
         /// If it's not set, allocated pages will be filled with zeroes.
-        const DIRTY_OK = 1 << 0;
+        const DIRTY_OK = 1 << 2;
     }
 }
 

--- a/runtime/spinlock.rs
+++ b/runtime/spinlock.rs
@@ -113,12 +113,12 @@ impl<'a, T: ?Sized> Drop for SpinLockGuard<'a, T> {
 impl<'a, T: ?Sized> Deref for SpinLockGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        &*self.inner
+        &self.inner
     }
 }
 
 impl<'a, T: ?Sized> DerefMut for SpinLockGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut *self.inner
+        &mut self.inner
     }
 }

--- a/runtime/x64/bootinfo.rs
+++ b/runtime/x64/bootinfo.rs
@@ -184,13 +184,10 @@ impl Cmdline {
                         }
                     }
                     (Some("virtio_mmio.device"), Some(value)) => {
-                        let mut size_and_rest = value.splitn(2, "@0x");
-                        let _size = size_and_rest.next().unwrap();
-                        let rest = size_and_rest.next().unwrap();
-
-                        let mut addr_and_irq = rest.splitn(2, ':');
-                        let addr = usize::from_str_radix(addr_and_irq.next().unwrap(), 16).unwrap();
-                        let irq = addr_and_irq.next().unwrap().parse().unwrap();
+                        let (_size, rest) = value.split_once("@0x").unwrap();
+                        let (addr, irq) = rest.split_once(':').unwrap();
+                        let addr = usize::from_str_radix(addr, 16).unwrap();
+                        let irq = irq.parse().unwrap();
 
                         info!(
                             "bootinfo: virtio MMIO device: base={:016x}, irq={}",

--- a/runtime/x64/interrupt.rs
+++ b/runtime/x64/interrupt.rs
@@ -37,12 +37,15 @@ struct InterruptFrame {
 }
 
 impl fmt::Debug for InterruptFrame {
-    #[allow(unaligned_references)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let rip = self.rip;
+        let rsp = self.rsp;
+        let cs = self.cs;
+        let error = self.error;
         write!(
             f,
             "RIP={:x}, RSP={:x}, CS={:x}, ERR={:x}",
-            self.rip, self.rsp, self.cs, self.error
+            rip, rsp, cs, error
         )
     }
 }
@@ -54,7 +57,6 @@ extern "C" {
 }
 
 #[no_mangle]
-#[allow(unaligned_references)]
 unsafe extern "C" fn x64_handle_interrupt(vec: u8, frame: *const InterruptFrame) {
     let frame = &*frame;
 
@@ -66,12 +68,15 @@ unsafe extern "C" fn x64_handle_interrupt(vec: u8, frame: *const InterruptFrame)
         && vec != 14
         && vec != 36
     {
+        let rip = frame.rip;
+        let rsp = frame.rsp;
+        let error = frame.error;
         trace!(
             "interrupt({}): rip={:x}, rsp={:x}, err={:x}, cr2={:x}",
             vec,
-            frame.rip,
-            frame.rsp,
-            frame.error,
+            rip,
+            rsp,
+            error,
             x86::controlregs::cr2()
         );
     }
@@ -164,10 +169,12 @@ unsafe extern "C" fn x64_handle_interrupt(vec: u8, frame: *const InterruptFrame)
                 || frame.rip == usercopy2 as *const u8 as u64
                 || frame.rip == usercopy3 as *const u8 as u64;
             if !occurred_in_user {
+                let rip = frame.rip; // Move out of unaligned
+                let rsp = frame.rsp; // Move out of unaligned
                 panic!(
                     "page fault occurred in the kernel: rip={:x}, rsp={:x}, vaddr={:x}",
-                    frame.rip,
-                    frame.rsp,
+                    rip,
+                    rsp,
                     cr2()
                 );
             }

--- a/runtime/x64/interrupt.rs
+++ b/runtime/x64/interrupt.rs
@@ -180,7 +180,7 @@ unsafe extern "C" fn x64_handle_interrupt(vec: u8, frame: *const InterruptFrame)
             }
 
             // Abort if the virtual address points to out of the user's address space.
-            let unaligned_vaddr = UserVAddr::new(cr2() as usize);
+            let unaligned_vaddr = UserVAddr::new(cr2());
             handler().handle_page_fault(unaligned_vaddr, frame.rip as usize, reason);
         }
         X87_FPU_VECTOR => {

--- a/runtime/x64/paging.rs
+++ b/runtime/x64/paging.rs
@@ -91,7 +91,7 @@ fn duplicate_table(original_table_paddr: PAddr, level: usize) -> Result<PAddr, P
 
     debug_assert!(level > 0);
     for i in 0..ENTRIES_PER_TABLE {
-        let entry = unsafe { *orig_table.offset(i as isize) };
+        let entry = unsafe { *orig_table.offset(i) };
         let paddr = entry_paddr(entry);
 
         // Check if we need to copy the entry.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-03-24"
+channel = "nightly-2024-01-01"
 components = [ "rustfmt", "clippy", "llvm-tools-preview", "rust-src" ]

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -65,6 +65,6 @@ ADD etc/group /etc
 ADD etc/passwd /etc
 ADD etc/profile /etc
 ADD integration_tests /integration_tests
-RUN echo "<html><body><h1>It works on Kerla!</h1></body></html>" > /var/www/html/index.html
+ADD var/www/html/index.html /var/www/html/index.html
 
 CMD ["/bin/sh"]

--- a/testing/var/www/html/index.html
+++ b/testing/var/www/html/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<body>
+    <h1>It works on Kerla!</h1>
+</body>
+
+</html>


### PR DESCRIPTION
## Description

When I started hacking on kerla, the CI was failing due to unpinned crates being installed.  Rather than check what version CI used to be running, I bumped the rust nightly we use until it built the deps again, fixed the clippies, and then pinned those crates.

## Pre-Submission Checklist

When you submit a PR, please make sure your PR satisfies the following checklist:

- [x] I assert this contribution was authored by me.
- [x] I license this contribution under the license of this project.
- [x] The PR title describes your changes briefly and uses the present tense, without a trailing full stop.
- [x] The PR description describes the reason why we need the change.
- [x] This is an isolated change. No multiple changes and no unrelated changes are included.
- [x] Fixed all `cargo clippy` warnings.
- [x] Applied `rustfmt`.
